### PR TITLE
Add OpenAPI schema generation utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ condaenv.*.requirements.txt
 
 # uv build temp file
 /.ok
+
+openapi.json
+openapi.yaml

--- a/docs/generate_html.sh
+++ b/docs/generate_html.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ENV_NAME=eq1_pulse-dev
 cd $(dirname $0)
 conda run --live-stream -n $ENV_NAME make html

--- a/docs/generate_pdf.sh
+++ b/docs/generate_pdf.sh
@@ -1,2 +1,4 @@
+#!/bin/bash
 ENV_NAME=eq1_pulse-dev
+cd $(dirname $0)
 conda run --live-stream -n $ENV_NAME make LATEXMKOPTS="-f -interaction=nonstopmode" latexpdf

--- a/docs/openapi_generator_README.md
+++ b/docs/openapi_generator_README.md
@@ -1,0 +1,145 @@
+# OpenAPI Schema Generator for eq1_pulse Models
+
+This module provides functionality to automatically generate OpenAPI 3.1.0 schemas from the Pydantic models in the `eq1_pulse.models` package.
+
+This is an AI generated module for the `eq1_pulse`  based on the Speakeasy Pydantic guide, [available here](https://www.speakeasy.com/openapi/frameworks/pydantic):
+
+
+## Overview
+
+The OpenAPI schema generator discovers all Pydantic models in the eq1_pulse models package and creates a comprehensive OpenAPI schema that can be used for:
+
+- SDK generation
+- API documentation
+- Client library generation
+- Integration with API development tools
+
+## Features
+
+- Automatic Model Discovery: Recursively finds all Pydantic models in the models package
+- OpenAPI 3.1.0 Compliant: Generates schemas compatible with the latest OpenAPI specification
+- Save schemas as JSON or YAML
+- Uses `#/components/schemas` references for inter-model relationships
+- Groups models by category (basic types, pulse types, channel operations, etc.)
+- Comprehensive documentation: went all the way to include model descriptions, field descriptions, and examples
+
+## Installation
+
+The module is part of the `eq1_pulse` package. To use YAML export, install ruamel.yaml:
+
+```bash
+pip install ruamel.yaml
+```
+
+## Usage
+
+### Basic Usage
+
+```python
+from eq1_pulse.utilities.openapi_generator import generate_openapi_schema, save_openapi_schema
+
+# Generate the schema
+schema = generate_openapi_schema()
+
+# Save to JSON
+save_openapi_schema(schema, "openapi.json", format="json")
+
+# Save to YAML (requires ruamel.yaml)
+save_openapi_schema(schema, "openapi.yaml", format="yaml")
+```
+
+### Command-Line Usage
+
+You can run the generator as a module:
+
+```bash
+python -m eq1_pulse.utilities.openapi_generator
+```
+
+This will generate both `openapi.json` and `openapi.yaml` files in the current directory.
+
+### Example Script
+
+See `examples/generate_openapi_example.py` for a complete example:
+
+```bash
+python examples/generate_openapi_example.py
+```
+
+### Advanced Usage
+
+```python
+from eq1_pulse.utilities.openapi_generator import (
+    generate_openapi_schema,
+    get_all_pydantic_models,
+    save_openapi_schema,
+)
+
+# Discover all models
+models = get_all_pydantic_models()
+print(f"Found {len(models)} models")
+
+# Generate custom schema
+schema = generate_openapi_schema(
+    title="My Custom API",
+    version="2.0.0",
+    description="Custom description for my API",
+    include_tags=True,
+)
+
+# Save with custom path
+save_openapi_schema(schema, "output/my_schema.yaml", format="yaml")
+```
+
+## Generated Schema Structure
+
+The generated OpenAPI schema includes:
+
+```yaml
+openapi: 3.1.0
+info:
+  title: Equal1 Pulse Models API
+  version: 1.0.0
+  description: OpenAPI schema for Equal1 Pulse library models...
+tags:
+  - name: basic-types
+    description: Basic types like Amplitude, Duration, Frequency, etc.
+  - name: pulse-types
+    description: Pulse type definitions (Square, Sine, Arbitrary, etc.)
+  # ... more tags
+components:
+  schemas:
+    SquarePulse:
+      # Model definition
+    SinePulse:
+      # Model definition
+    # ... all other models
+```
+
+## Integration with SDK Generators
+
+The generated schema is compatible with various OpenAPI tools:
+- [OpenAPI Generator](https://openapi-generator.tech/)
+- [Swagger Codegen](https://swagger.io/tools/swagger-codegen/)
+- [FastAPI](https://fastapi.tiangolo.com/) (can import the models directly)
+- [Redoc](https://redocly.com/redoc/) (for documentation)
+
+## Implementation Details
+
+The generator uses Pydantic's `models_json_schema()` function to create JSON schemas for all models, then wraps them in the OpenAPI document structure. It:
+
+1. **Discovers models**: Imports all modules in `eq1_pulse.models` and extracts Pydantic classes
+2. **Filters base classes**: Excludes abstract base classes like `FrozenModel`, `NoExtrasModel`, etc.
+3. **Generates schemas**: Uses Pydantic's schema generation with OpenAPI-compatible references
+4. **Adds metadata**: Includes OpenAPI info, tags, and other metadata
+5. **Exports**: Saves to JSON or YAML format
+
+## References
+
+- [Pydantic OpenAPI Guide](https://www.speakeasy.com/openapi/frameworks/pydantic)
+- [OpenAPI 3.1.0 Specification](https://spec.openapis.org/oas/v3.1.0)
+- [Pydantic JSON Schema Documentation](https://docs.pydantic.dev/latest/concepts/json_schema/)
+
+## License
+
+Same as the `eq1_pulse` package.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ eq1lab documentation
 
    autoapi/eq1_pulse/models/index.rst
 
+   autoapi/eq1_pulse/utilities/index.rst
 
 .. # Indices and tables
 .. # ==================

--- a/output/eq1_pulse_openapi.json
+++ b/output/eq1_pulse_openapi.json
@@ -1,0 +1,2685 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Equal1 Pulse Models API",
+    "version": "1.0.0",
+    "description": "OpenAPI schema for Equal1 Pulse library models. This schema defines all the Pydantic models used for pulse sequencing, channel operations, control flow, and data operations."
+  },
+  "components": {
+    "schemas": {
+      "Amplitude": {
+        "additionalProperties": false,
+        "description": "Model to represent the (complex) amplitude of a voltage signal.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComplexVolts"
+              },
+              {
+                "$ref": "#/components/schemas/ComplexMillivolts"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Amplitude",
+        "type": "object"
+      },
+      "Angle": {
+        "additionalProperties": false,
+        "description": "A model representing an angle in either degrees, radians, turns or half-turns.\n\nTurns are also known as revolutions or cycles, also :math:`\\tau=2\\pi` radians or 360\u00b0.\nHalf-turns are also known as half-cycles, also :math:`\\pi` radians or 180\u00b0.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Degrees"
+              },
+              {
+                "$ref": "#/components/schemas/Radians"
+              },
+              {
+                "$ref": "#/components/schemas/Turns"
+              },
+              {
+                "$ref": "#/components/schemas/HalfTurns"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Angle",
+        "type": "object"
+      },
+      "ArbitrarySampledPulse": {
+        "additionalProperties": false,
+        "description": "Pulse type that uses arbitrary sampled waveform data.\n\nThe amplitude refers to the reference amplitude of the pulse, which is usually the peak amplitude.\nThe duration refers to the total duration of the pulse.\nThe samples (complex or real) are expected to be normalized between -1 and 1, and will be scaled by the amplitude.\nThe samples are uniformly distributed over the duration of the pulse, with interpolation applied as needed.",
+        "properties": {
+          "pulse_type": {
+            "const": "arbitrary",
+            "default": "arbitrary",
+            "title": "Pulse Type",
+            "type": "string"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Duration"
+          },
+          "amplitude": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Amplitude"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Amplitude"
+          },
+          "samples": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NumpyFloatArray1D"
+              },
+              {
+                "$ref": "#/components/schemas/NumpyComplexArray1D"
+              }
+            ],
+            "title": "Samples"
+          },
+          "interpolation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Interpolation"
+          },
+          "time_points": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NumpyFloatArray1D"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "duration",
+          "amplitude",
+          "samples"
+        ],
+        "title": "ArbitrarySampledPulse",
+        "type": "object"
+      },
+      "ArithmeticFrozenWrappedValueModel": {
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "ArithmeticFrozenWrappedValueModel",
+        "type": "object"
+      },
+      "ArithmeticFrozenWrappedValueModel_Union_int__float__": {
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "ArithmeticFrozenWrappedValueModel[Union[int, float]]",
+        "type": "object"
+      },
+      "ArithmeticFrozenWrappedValueModel_Union_int__float__complex__": {
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "ArithmeticFrozenWrappedValueModel[Union[int, float, complex]]",
+        "type": "object"
+      },
+      "Barrier": {
+        "additionalProperties": false,
+        "description": "Synchronize channels.\n\nThe barrier operation causes channels to wait until all channels have reached the barrier.",
+        "properties": {
+          "op_type": {
+            "const": "barrier",
+            "default": "barrier",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/ChannelRef"
+            },
+            "title": "Channels",
+            "type": "array"
+          }
+        },
+        "required": [
+          "channels"
+        ],
+        "title": "Barrier",
+        "type": "object"
+      },
+      "ChannelOp": {
+        "discriminator": {
+          "mapping": {
+            "barrier": "#/components/schemas/Barrier",
+            "dc_comp": "#/components/schemas/CompensateDC",
+            "play": "#/components/schemas/Play",
+            "record": "#/components/schemas/Record",
+            "set_frequency": "#/components/schemas/SetFrequency",
+            "set_phase": "#/components/schemas/SetPhase",
+            "shift_frequency": "#/components/schemas/ShiftFrequency",
+            "shift_phase": "#/components/schemas/ShiftPhase",
+            "trace": "#/components/schemas/Trace",
+            "wait": "#/components/schemas/Wait"
+          },
+          "propertyName": "op_type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Play"
+          },
+          {
+            "$ref": "#/components/schemas/Wait"
+          },
+          {
+            "$ref": "#/components/schemas/Barrier"
+          },
+          {
+            "$ref": "#/components/schemas/SetFrequency"
+          },
+          {
+            "$ref": "#/components/schemas/ShiftFrequency"
+          },
+          {
+            "$ref": "#/components/schemas/SetPhase"
+          },
+          {
+            "$ref": "#/components/schemas/ShiftPhase"
+          },
+          {
+            "$ref": "#/components/schemas/Record"
+          },
+          {
+            "$ref": "#/components/schemas/Trace"
+          },
+          {
+            "$ref": "#/components/schemas/CompensateDC"
+          }
+        ]
+      },
+      "ChannelOpBase": {
+        "additionalProperties": false,
+        "description": "Base class for operations involving a single channel.",
+        "properties": {
+          "op_type": {
+            "title": "Op Type"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          }
+        },
+        "required": [
+          "op_type",
+          "channel"
+        ],
+        "title": "ChannelOpBase",
+        "type": "object"
+      },
+      "ChannelRef": {
+        "description": "Reference to a channel.\n\nChannels are defined in the target's hardware configuration.",
+        "properties": {
+          "channel": {
+            "$ref": "#/components/schemas/IdentifierStr"
+          }
+        },
+        "required": [
+          "channel"
+        ],
+        "title": "ChannelRef",
+        "type": "object"
+      },
+      "ChannelsOpBase": {
+        "additionalProperties": false,
+        "description": "Base class for operations involving multiple channels.",
+        "properties": {
+          "op_type": {
+            "title": "Op Type"
+          },
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/ChannelRef"
+            },
+            "title": "Channels",
+            "type": "array"
+          }
+        },
+        "required": [
+          "op_type",
+          "channels"
+        ],
+        "title": "ChannelsOpBase",
+        "type": "object"
+      },
+      "ComparisonMode": {
+        "enum": [
+          ">=",
+          ">",
+          "<=",
+          "<"
+        ],
+        "title": "ComparisonMode",
+        "type": "string"
+      },
+      "CompensateDC": {
+        "additionalProperties": false,
+        "description": "Apply DC offset compensation to the channel.\n\nA square wave of specified duration is played on the channel. The amplitude of the wave is calculated to\nresult in a zero average value when integrated over the duration since the laste reset.\n\nIf ``null``/:obj:`None` duration is specified, the accumulated value is reset to zero, without\nplaying a compensation pulse.\n\nIf ``max_amp`` is specified, the amplitude of the compensation pulse is limited to that value.\nIf the amplitude is calculated to be higher, the pulse area is subtracted from the accumulated value,\nleaving the possibility to compensate the rest in the following operations.\n\nIf ``rise_time`` and ``fall_time`` are specified, they define the duration of linear ramps\nat the beginning and end of the compensation pulse. The ramps are included in the area calculation.\nThe rise and fall times are also included in the total duration of the compensation pulse.",
+        "properties": {
+          "op_type": {
+            "const": "dc_comp",
+            "default": "dc_comp",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration"
+          },
+          "max_amp": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Magnitude"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "rise_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Rise Time"
+          },
+          "fall_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Fall Time"
+          }
+        },
+        "required": [
+          "channel",
+          "duration"
+        ],
+        "title": "CompensateDC",
+        "type": "object"
+      },
+      "ComplexMillivolts": {
+        "additionalProperties": false,
+        "description": "Millivolts as a unit of voltage (real + imaginary).",
+        "properties": {
+          "mV": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/components/schemas/complex_from_tuple"
+              }
+            ],
+            "title": "Mv"
+          }
+        },
+        "required": [
+          "mV"
+        ],
+        "title": "ComplexMillivolts",
+        "type": "object"
+      },
+      "ComplexToRealProjectionMode": {
+        "enum": [
+          "real",
+          "imag",
+          "abs",
+          "phase"
+        ],
+        "title": "ComplexToRealProjectionMode",
+        "type": "string"
+      },
+      "ComplexVoltage": {
+        "additionalProperties": false,
+        "description": "A model representing a complex voltage in volts or millivolts.\n\nComplex voltages are used to represent both amplitude and phase information,\nand are used with with mixing or demodulation operations.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ComplexVolts"
+              },
+              {
+                "$ref": "#/components/schemas/ComplexMillivolts"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "ComplexVoltage",
+        "type": "object"
+      },
+      "ComplexVolts": {
+        "additionalProperties": false,
+        "description": "Volts as a unit of voltage (real + imaginary).",
+        "properties": {
+          "V": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/components/schemas/complex_from_tuple"
+              }
+            ],
+            "title": "V"
+          }
+        },
+        "required": [
+          "V"
+        ],
+        "title": "ComplexVolts",
+        "type": "object"
+      },
+      "Conditional": {
+        "additionalProperties": false,
+        "description": "Represents a conditional sequence of operations.\n\n:ivar op_type: Operation type, always \"if\"\n:ivar var: The variable reference for the condition.\n:ivar body: The sequence of operations to execute if the condition is met",
+        "properties": {
+          "op_type": {
+            "const": "if",
+            "default": "if",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "body": {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        },
+        "required": [
+          "var",
+          "body"
+        ],
+        "title": "Conditional",
+        "type": "object"
+      },
+      "ConditionalBase_OpSequence_": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "if",
+            "default": "if",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "body": {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        },
+        "required": [
+          "var",
+          "body"
+        ],
+        "title": "ConditionalBase[OpSequence]",
+        "type": "object"
+      },
+      "ConditionalBase_Schedule_": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "if",
+            "default": "if",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "var",
+          "body"
+        ],
+        "title": "ConditionalBase[Schedule]",
+        "type": "object"
+      },
+      "DataOpBase": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "title": "Op Type"
+          }
+        },
+        "required": [
+          "op_type"
+        ],
+        "title": "DataOpBase",
+        "type": "object"
+      },
+      "Degrees": {
+        "additionalProperties": false,
+        "description": "Degrees as a unit of angle.",
+        "properties": {
+          "deg": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Deg"
+          }
+        },
+        "required": [
+          "deg"
+        ],
+        "title": "Degrees",
+        "type": "object"
+      },
+      "DemodIntegration": {
+        "additionalProperties": false,
+        "description": "Demodulation integration of measured values.\n\nThe demodulation operation will multiply the measured signal with\nthe channels' output signal before integration.\nIf scale_cos/scale_sin are specified they can be used to scale and \"flip\" the real/imaginary parts of the result.\n\nAn optional phase may be applied to rotate the result.",
+        "properties": {
+          "integration_type": {
+            "const": "demod",
+            "default": "demod",
+            "title": "Integration Type",
+            "type": "string"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Phase"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "scale_cos": {
+            "default": 1,
+            "title": "Scale Cos",
+            "type": "number"
+          },
+          "scale_sin": {
+            "default": 1,
+            "title": "Scale Sin",
+            "type": "number"
+          }
+        },
+        "title": "DemodIntegration",
+        "type": "object"
+      },
+      "DiscriminableOp": {
+        "discriminator": {
+          "mapping": {
+            "barrier": "#/components/schemas/ChannelOp",
+            "dc_comp": "#/components/schemas/ChannelOp",
+            "discriminate": "#/components/schemas/Discriminate",
+            "for": "#/components/schemas/Iteration",
+            "if": "#/components/schemas/Conditional",
+            "play": "#/components/schemas/ChannelOp",
+            "pulse_decl": "#/components/schemas/PulseDecl",
+            "record": "#/components/schemas/ChannelOp",
+            "repeat": "#/components/schemas/Repetition",
+            "set_frequency": "#/components/schemas/ChannelOp",
+            "set_phase": "#/components/schemas/ChannelOp",
+            "shift_frequency": "#/components/schemas/ChannelOp",
+            "shift_phase": "#/components/schemas/ChannelOp",
+            "store": "#/components/schemas/Store",
+            "trace": "#/components/schemas/ChannelOp",
+            "var_decl": "#/components/schemas/VariableDecl",
+            "wait": "#/components/schemas/ChannelOp"
+          },
+          "propertyName": "op_type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChannelOp"
+          },
+          {
+            "$ref": "#/components/schemas/VariableDecl"
+          },
+          {
+            "$ref": "#/components/schemas/PulseDecl"
+          },
+          {
+            "$ref": "#/components/schemas/Discriminate"
+          },
+          {
+            "$ref": "#/components/schemas/Store"
+          },
+          {
+            "$ref": "#/components/schemas/Repetition"
+          },
+          {
+            "$ref": "#/components/schemas/Iteration"
+          },
+          {
+            "$ref": "#/components/schemas/Conditional"
+          }
+        ]
+      },
+      "DiscriminableSchedulableOp": {
+        "discriminator": {
+          "mapping": {
+            "barrier": "#/components/schemas/ChannelOp",
+            "dc_comp": "#/components/schemas/ChannelOp",
+            "discriminate": "#/components/schemas/Discriminate",
+            "for": "#/components/schemas/SchedIteration",
+            "if": "#/components/schemas/SchedConditional",
+            "play": "#/components/schemas/ChannelOp",
+            "pulse_decl": "#/components/schemas/PulseDecl",
+            "record": "#/components/schemas/ChannelOp",
+            "repeat": "#/components/schemas/SchedRepetition",
+            "set_frequency": "#/components/schemas/ChannelOp",
+            "set_phase": "#/components/schemas/ChannelOp",
+            "shift_frequency": "#/components/schemas/ChannelOp",
+            "shift_phase": "#/components/schemas/ChannelOp",
+            "store": "#/components/schemas/Store",
+            "trace": "#/components/schemas/ChannelOp",
+            "var_decl": "#/components/schemas/VariableDecl",
+            "wait": "#/components/schemas/ChannelOp"
+          },
+          "propertyName": "op_type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/ChannelOp"
+          },
+          {
+            "$ref": "#/components/schemas/VariableDecl"
+          },
+          {
+            "$ref": "#/components/schemas/PulseDecl"
+          },
+          {
+            "$ref": "#/components/schemas/Discriminate"
+          },
+          {
+            "$ref": "#/components/schemas/Store"
+          },
+          {
+            "$ref": "#/components/schemas/SchedRepetition"
+          },
+          {
+            "$ref": "#/components/schemas/SchedIteration"
+          },
+          {
+            "$ref": "#/components/schemas/SchedConditional"
+          }
+        ]
+      },
+      "Discriminate": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "discriminate",
+            "default": "discriminate",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "target": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "source": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "threshold": {
+            "$ref": "#/components/schemas/Threshold"
+          },
+          "rotation": {
+            "$ref": "#/components/schemas/Phase",
+            "default": {
+              "rad": 0.0
+            }
+          },
+          "compare": {
+            "$ref": "#/components/schemas/ComparisonMode",
+            "default": ">="
+          },
+          "project": {
+            "$ref": "#/components/schemas/ComplexToRealProjectionMode",
+            "default": "real"
+          }
+        },
+        "required": [
+          "target",
+          "source",
+          "threshold"
+        ],
+        "title": "Discriminate",
+        "type": "object"
+      },
+      "Duration": {
+        "additionalProperties": false,
+        "description": "Special case of non-negative Time representing a duration.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Seconds"
+              },
+              {
+                "$ref": "#/components/schemas/Milliseconds"
+              },
+              {
+                "$ref": "#/components/schemas/Microseconds"
+              },
+              {
+                "$ref": "#/components/schemas/Nanoseconds"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Duration",
+        "type": "object"
+      },
+      "ExternalPulse": {
+        "additionalProperties": false,
+        "description": "Pulse type that references an externally defined pulse function.\n\nThe amplitude refers to the reference amplitude of the pulse, which is usually the peak amplitude.\nThe duration refers to the total duration of the pulse.\n\nThe pulse function is expected to be defined elsewhere, such as in a pulse library or a hardware definition.",
+        "properties": {
+          "pulse_type": {
+            "const": "external",
+            "default": "external",
+            "title": "Pulse Type",
+            "type": "string"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Duration"
+          },
+          "amplitude": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Amplitude"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Amplitude"
+          },
+          "function": {
+            "$ref": "#/components/schemas/FullyQualifiedIdentifier"
+          },
+          "params": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/PulseParamValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Params"
+          }
+        },
+        "required": [
+          "duration",
+          "amplitude",
+          "function"
+        ],
+        "title": "ExternalPulse",
+        "type": "object"
+      },
+      "Frequency": {
+        "additionalProperties": false,
+        "description": "A model representing a frequency in Hertz, Kilohertz, Megahertz, or Gigahertz.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Hertz"
+              },
+              {
+                "$ref": "#/components/schemas/Kilohertz"
+              },
+              {
+                "$ref": "#/components/schemas/Megahertz"
+              },
+              {
+                "$ref": "#/components/schemas/Gigahertz"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Frequency",
+        "type": "object"
+      },
+      "FullIntegration": {
+        "additionalProperties": false,
+        "description": "Full summation of measured values.",
+        "properties": {
+          "integration_type": {
+            "const": "full",
+            "default": "full",
+            "title": "Integration Type",
+            "type": "string"
+          }
+        },
+        "title": "FullIntegration",
+        "type": "object"
+      },
+      "FullyQualifiedIdentifier": {
+        "type": "string"
+      },
+      "Gigahertz": {
+        "additionalProperties": false,
+        "description": "Gigahertz as a unit of frequency.",
+        "properties": {
+          "GHz": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Ghz"
+          }
+        },
+        "required": [
+          "GHz"
+        ],
+        "title": "Gigahertz",
+        "type": "object"
+      },
+      "HalfTurns": {
+        "additionalProperties": false,
+        "description": "Half turns as a unit of angle.\n\nA half turn is half a full rotation, i.e. 180 degrees or \u03c0 radians.",
+        "properties": {
+          "half_turns": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Half Turns"
+          }
+        },
+        "required": [
+          "half_turns"
+        ],
+        "title": "HalfTurns",
+        "type": "object"
+      },
+      "Hertz": {
+        "additionalProperties": false,
+        "description": "Hertz as a unit of frequency.",
+        "properties": {
+          "Hz": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Hz"
+          }
+        },
+        "required": [
+          "Hz"
+        ],
+        "title": "Hertz",
+        "type": "object"
+      },
+      "IdentifierStr": {
+        "type": "string"
+      },
+      "IntegrationType": {
+        "additionalProperties": false,
+        "description": "Base class for different types of integration operations.",
+        "properties": {
+          "integration_type": {
+            "title": "Integration Type"
+          }
+        },
+        "required": [
+          "integration_type"
+        ],
+        "title": "IntegrationType",
+        "type": "object"
+      },
+      "IterableSequence": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/LinSpace"
+          },
+          {
+            "$ref": "#/components/schemas/Range"
+          },
+          {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          {
+            "$ref": "#/components/schemas/NumpyIterableArray"
+          }
+        ]
+      },
+      "Iteration": {
+        "additionalProperties": false,
+        "description": "Represents an iteration over a sequence of operations.\n\n:ivar op_type: Operation type, always \"for\"\n:ivar var: The variable reference for the iterated value.\n:ivar items: The range or array over which to iterate.\n:ivar body: The sequence of operations to execute in each iteration",
+        "properties": {
+          "op_type": {
+            "const": "for",
+            "default": "for",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/VariableRef"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Var"
+          },
+          "items": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IterableSequence"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/IterableSequence"
+              }
+            ],
+            "title": "Items"
+          },
+          "body": {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        },
+        "required": [
+          "var",
+          "items",
+          "body"
+        ],
+        "title": "Iteration",
+        "type": "object"
+      },
+      "IterationBase_OpSequence_": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "for",
+            "default": "for",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/VariableRef"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Var"
+          },
+          "items": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IterableSequence"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/IterableSequence"
+              }
+            ],
+            "title": "Items"
+          },
+          "body": {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        },
+        "required": [
+          "var",
+          "items",
+          "body"
+        ],
+        "title": "IterationBase[OpSequence]",
+        "type": "object"
+      },
+      "IterationBase_Schedule_": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "for",
+            "default": "for",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/VariableRef"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Var"
+          },
+          "items": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IterableSequence"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/IterableSequence"
+              }
+            ],
+            "title": "Items"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "var",
+          "items",
+          "body"
+        ],
+        "title": "IterationBase[Schedule]",
+        "type": "object"
+      },
+      "Kilohertz": {
+        "additionalProperties": false,
+        "description": "Kilohertz as a unit of frequency.",
+        "properties": {
+          "kHz": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Khz"
+          }
+        },
+        "required": [
+          "kHz"
+        ],
+        "title": "Kilohertz",
+        "type": "object"
+      },
+      "LinSpace": {
+        "additionalProperties": false,
+        "description": "Represents a linear space between two values.\n\n:ivar start: Starting value (can be real or complex)\n:ivar stop: Ending value (can be real or complex)\n:ivar num: Number of points in the space, including endpoints.",
+        "properties": {
+          "start": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Start"
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Stop"
+          },
+          "num": {
+            "minimum": 1,
+            "title": "Num",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "start",
+          "stop",
+          "num"
+        ],
+        "title": "LinSpace",
+        "type": "object"
+      },
+      "Magnitude": {
+        "additionalProperties": false,
+        "description": "Special case of non-negative real Voltage representing a maximum amplitude.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Volts"
+              },
+              {
+                "$ref": "#/components/schemas/Millivolts"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Magnitude",
+        "type": "object"
+      },
+      "Megahertz": {
+        "additionalProperties": false,
+        "description": "Megahertz as a unit of frequency.",
+        "properties": {
+          "MHz": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Mhz"
+          }
+        },
+        "required": [
+          "MHz"
+        ],
+        "title": "Megahertz",
+        "type": "object"
+      },
+      "Microseconds": {
+        "additionalProperties": false,
+        "description": "Microseconds as a unit of time.",
+        "properties": {
+          "us": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Us"
+          }
+        },
+        "required": [
+          "us"
+        ],
+        "title": "Microseconds",
+        "type": "object"
+      },
+      "Milliseconds": {
+        "additionalProperties": false,
+        "description": "Milliseconds as a unit of time.",
+        "properties": {
+          "ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Ms"
+          }
+        },
+        "required": [
+          "ms"
+        ],
+        "title": "Milliseconds",
+        "type": "object"
+      },
+      "Millivolts": {
+        "additionalProperties": false,
+        "description": "Millivolts as a unit of voltage (real).",
+        "properties": {
+          "mV": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Mv"
+          }
+        },
+        "required": [
+          "mV"
+        ],
+        "title": "Millivolts",
+        "type": "object"
+      },
+      "Nanoseconds": {
+        "additionalProperties": false,
+        "description": "Nanoseconds as a unit of time.",
+        "properties": {
+          "ns": {
+            "title": "Ns",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "ns"
+        ],
+        "title": "Nanoseconds",
+        "type": "object"
+      },
+      "NumpyComplexArray1D": {
+        "items": {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        },
+        "type": "array"
+      },
+      "NumpyFloatArray1D": {
+        "items": {
+          "type": "number"
+        },
+        "type": "array"
+      },
+      "NumpyIntArray1D": {
+        "items": {
+          "type": "integer"
+        },
+        "type": "array"
+      },
+      "NumpyIterableArray": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/NumpyIntArray1D"
+          },
+          {
+            "$ref": "#/components/schemas/NumpyFloatArray1D"
+          },
+          {
+            "$ref": "#/components/schemas/NumpyComplexArray1D"
+          }
+        ]
+      },
+      "OpSequence": {
+        "additionalProperties": false,
+        "description": "A sequence of operation items that can be serialized as a list.\n\nThis class represents an ordered collection of operation sequence items that\nwill be serialized as a list when converted to JSON or other formats.\n\n:ivar items: List of operation sequence items",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OpSequenceItem"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "OpSequence",
+        "type": "object"
+      },
+      "OpSequenceItem": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/DiscriminableOp"
+          },
+          {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        ]
+      },
+      "Phase": {
+        "additionalProperties": false,
+        "description": "Special case of Angle where the value represents a phase angle.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Degrees"
+              },
+              {
+                "$ref": "#/components/schemas/Radians"
+              },
+              {
+                "$ref": "#/components/schemas/Turns"
+              },
+              {
+                "$ref": "#/components/schemas/HalfTurns"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Phase",
+        "type": "object"
+      },
+      "Play": {
+        "additionalProperties": false,
+        "description": "Play a pulse on a channel.",
+        "properties": {
+          "op_type": {
+            "const": "play",
+            "default": "play",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "pulse": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PulseType"
+              },
+              {
+                "$ref": "#/components/schemas/PulseRef"
+              }
+            ],
+            "title": "Pulse"
+          },
+          "scale_amp": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Scale Amp"
+          },
+          "cond": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "channel",
+          "pulse"
+        ],
+        "title": "Play",
+        "type": "object"
+      },
+      "PulseDecl": {
+        "additionalProperties": false,
+        "description": "Pulse declaration operation.\n\nPulses must be declared before they can be referred to.\nPulse declarations are scoped to the surrounding context and its children.",
+        "properties": {
+          "op_type": {
+            "const": "pulse_decl",
+            "default": "pulse_decl",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "pulse": {
+            "$ref": "#/components/schemas/PulseType"
+          }
+        },
+        "required": [
+          "name",
+          "pulse"
+        ],
+        "title": "PulseDecl",
+        "type": "object"
+      },
+      "PulseParamScalarValue": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "PulseParamValue": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Amplitude"
+          },
+          {
+            "$ref": "#/components/schemas/Duration"
+          },
+          {
+            "$ref": "#/components/schemas/Frequency"
+          },
+          {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          {
+            "$ref": "#/components/schemas/PulseParamScalarValue"
+          }
+        ]
+      },
+      "PulseRef": {
+        "description": "Reference to a pulse.\n\nPulses must be declared in the surrounding context or one of its parents.",
+        "properties": {
+          "pulse_name": {
+            "$ref": "#/components/schemas/IdentifierStr"
+          }
+        },
+        "required": [
+          "pulse_name"
+        ],
+        "title": "PulseRef",
+        "type": "object"
+      },
+      "PulseType": {
+        "discriminator": {
+          "mapping": {
+            "arbitrary": "#/components/schemas/ArbitrarySampledPulse",
+            "external": "#/components/schemas/ExternalPulse",
+            "sine": "#/components/schemas/SinePulse",
+            "square": "#/components/schemas/SquarePulse"
+          },
+          "propertyName": "pulse_type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/SquarePulse"
+          },
+          {
+            "$ref": "#/components/schemas/SinePulse"
+          },
+          {
+            "$ref": "#/components/schemas/ExternalPulse"
+          },
+          {
+            "$ref": "#/components/schemas/ArbitrarySampledPulse"
+          }
+        ]
+      },
+      "Radians": {
+        "additionalProperties": false,
+        "description": "Radians as a unit of angle.",
+        "properties": {
+          "rad": {
+            "title": "Rad",
+            "type": "number"
+          }
+        },
+        "required": [
+          "rad"
+        ],
+        "title": "Radians",
+        "type": "object"
+      },
+      "Range": {
+        "additionalProperties": false,
+        "description": "Represents a range of values with a start, stop, and step.\n\nThe step can only be zero if the start and stop values are equal. Otherwise,\nthe step must evenly divide the difference between the start and stop values.\n\nIn case of complex numbers, the the difference must be an integral multiple of the step.\nThe sign of the step is adjusted to ensure the stop value is reached.\n\nThe stop point is always included in the range.\n\n:ivar start: Starting value (can be real or complex)\n:ivar stop: Ending value (can be real or complex) included in the range\n:ivar step: Step size (can be real or complex)",
+        "properties": {
+          "start": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Start"
+          },
+          "stop": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Stop"
+          },
+          "step": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "$ref": "#/components/schemas/complex_from_tuple"
+              }
+            ],
+            "title": "Step"
+          }
+        },
+        "required": [
+          "start",
+          "stop",
+          "step"
+        ],
+        "title": "Range",
+        "type": "object"
+      },
+      "Record": {
+        "additionalProperties": false,
+        "description": "Acquire scalar data from the channel with integration.\n\nThe integration type can be either \"full\" or \"demod\".\nFull integration is a simple accumulation of the signal.\nDemod integration is a complex multiplication of the signal with the channel's\nfrequency and phase followed by accumulation.\n\nThe result of the integration is saved into a scalar (complex) variable.\n\nFurther processing may be applied to the result, such as projection to real/imaginary parts,\nsee :class:`Discriminate`.",
+        "properties": {
+          "op_type": {
+            "const": "record",
+            "default": "record",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "var": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "duration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "integration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FullIntegration"
+              },
+              {
+                "$ref": "#/components/schemas/DemodIntegration"
+              }
+            ],
+            "title": "Integration"
+          },
+          "time_of_flight": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "channel",
+          "var",
+          "duration",
+          "integration"
+        ],
+        "title": "Record",
+        "type": "object"
+      },
+      "RefPt": {
+        "description": "An enumeration of reference points for Schedulables.\n\nThese represent the alignment points of the existing and the newly inserted schedulable.",
+        "enum": [
+          "start",
+          "end",
+          "center"
+        ],
+        "title": "RefPt",
+        "type": "string"
+      },
+      "Reference": {
+        "description": "Base class for all symbolic references.\n\nDescendants must only define a single field (the reference name), which is serialized directly.",
+        "properties": {},
+        "title": "Reference",
+        "type": "object"
+      },
+      "RelTime": {
+        "additionalProperties": false,
+        "description": "A subclass of Time representing relative time between Schedulables.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Seconds"
+              },
+              {
+                "$ref": "#/components/schemas/Milliseconds"
+              },
+              {
+                "$ref": "#/components/schemas/Microseconds"
+              },
+              {
+                "$ref": "#/components/schemas/Nanoseconds"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "RelTime",
+        "type": "object"
+      },
+      "Repetition": {
+        "additionalProperties": false,
+        "description": "Represents a repeated sequence of operations.\n\n:ivar op_type: Operation type, always \"repeat\"\n:ivar count: Number of times to repeat the sequence\n:ivar body: The sequence of operations to repeat",
+        "properties": {
+          "op_type": {
+            "const": "repeat",
+            "default": "repeat",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "count": {
+            "minimum": 0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "body": {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        },
+        "required": [
+          "count",
+          "body"
+        ],
+        "title": "Repetition",
+        "type": "object"
+      },
+      "RepetitionBase_OpSequence_": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "repeat",
+            "default": "repeat",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "count": {
+            "minimum": 0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "body": {
+            "$ref": "#/components/schemas/OpSequence"
+          }
+        },
+        "required": [
+          "count",
+          "body"
+        ],
+        "title": "RepetitionBase[OpSequence]",
+        "type": "object"
+      },
+      "RepetitionBase_Schedule_": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "repeat",
+            "default": "repeat",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "count": {
+            "minimum": 0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "count",
+          "body"
+        ],
+        "title": "RepetitionBase[Schedule]",
+        "type": "object"
+      },
+      "SchedConditional": {
+        "additionalProperties": false,
+        "description": "A class representing a conditional embedded in a schedule.",
+        "properties": {
+          "op_type": {
+            "const": "if",
+            "default": "if",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "var",
+          "body"
+        ],
+        "title": "SchedConditional",
+        "type": "object"
+      },
+      "SchedIteration": {
+        "additionalProperties": false,
+        "description": "A class representing an iterated schedule in a schedule.",
+        "properties": {
+          "op_type": {
+            "const": "for",
+            "default": "for",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "var": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/VariableRef"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Var"
+          },
+          "items": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/IterableSequence"
+                },
+                "type": "array"
+              },
+              {
+                "$ref": "#/components/schemas/IterableSequence"
+              }
+            ],
+            "title": "Items"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "var",
+          "items",
+          "body"
+        ],
+        "title": "SchedIteration",
+        "type": "object"
+      },
+      "SchedRepetition": {
+        "additionalProperties": false,
+        "description": "A class representing repeated schedule embedded in a schedule.",
+        "properties": {
+          "op_type": {
+            "const": "repeat",
+            "default": "repeat",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "count": {
+            "minimum": 0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "body": {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        },
+        "required": [
+          "count",
+          "body"
+        ],
+        "title": "SchedRepetition",
+        "type": "object"
+      },
+      "Schedulable": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/DiscriminableSchedulableOp"
+          },
+          {
+            "$ref": "#/components/schemas/Schedule"
+          }
+        ]
+      },
+      "Schedule": {
+        "additionalProperties": false,
+        "description": "A collection of scheduled operations.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ScheduledOperation"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "Schedule",
+        "type": "object"
+      },
+      "ScheduledOperation": {
+        "additionalProperties": false,
+        "description": "A class representing a scheduled operation with timing and reference information.\n\n:param name: Optional name for the operation\n:param rel_time: Relative time from the reference point\n:param ref_op: Name of the reference operation\n:param ref_pt: Reference point on the reference operation\n:param ref_pt_new: Reference point on the new operation\n:param op: The schedulable operation",
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Name"
+          },
+          "rel_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RelTime"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "ref_op": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Ref Op"
+          },
+          "ref_pt": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RefPt"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "ref_pt_new": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RefPt"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          },
+          "op": {
+            "$ref": "#/components/schemas/Schedulable"
+          }
+        },
+        "required": [
+          "op"
+        ],
+        "title": "ScheduledOperation",
+        "type": "object"
+      },
+      "Seconds": {
+        "additionalProperties": false,
+        "description": "Seconds as a unit of time.",
+        "properties": {
+          "s": {
+            "title": "S",
+            "type": "number"
+          }
+        },
+        "required": [
+          "s"
+        ],
+        "title": "Seconds",
+        "type": "object"
+      },
+      "SequenceBase_OpSequenceItem_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/OpSequenceItem"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "SequenceBase[OpSequenceItem]",
+        "type": "object"
+      },
+      "SequenceBase_ScheduledOperation_": {
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ScheduledOperation"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "SequenceBase[ScheduledOperation]",
+        "type": "object"
+      },
+      "SetFrequency": {
+        "additionalProperties": false,
+        "description": "Set the frequency of a channel.",
+        "properties": {
+          "op_type": {
+            "const": "set_frequency",
+            "default": "set_frequency",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "frequency": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Frequency"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Frequency"
+          }
+        },
+        "required": [
+          "channel",
+          "frequency"
+        ],
+        "title": "SetFrequency",
+        "type": "object"
+      },
+      "SetPhase": {
+        "additionalProperties": false,
+        "description": "Set the phase of a channel.",
+        "properties": {
+          "op_type": {
+            "const": "set_phase",
+            "default": "set_phase",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Phase"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Phase"
+          }
+        },
+        "required": [
+          "channel",
+          "phase"
+        ],
+        "title": "SetPhase",
+        "type": "object"
+      },
+      "ShiftFrequency": {
+        "additionalProperties": false,
+        "description": "Add a frequency shift to the channel frequency.",
+        "properties": {
+          "op_type": {
+            "const": "shift_frequency",
+            "default": "shift_frequency",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "frequency": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Frequency"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Frequency"
+          }
+        },
+        "required": [
+          "channel",
+          "frequency"
+        ],
+        "title": "ShiftFrequency",
+        "type": "object"
+      },
+      "ShiftPhase": {
+        "additionalProperties": false,
+        "description": "Add a phase shift to the channel phase.",
+        "properties": {
+          "op_type": {
+            "const": "shift_phase",
+            "default": "shift_phase",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "phase": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Phase"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Phase"
+          }
+        },
+        "required": [
+          "channel",
+          "phase"
+        ],
+        "title": "ShiftPhase",
+        "type": "object"
+      },
+      "SinePulse": {
+        "additionalProperties": false,
+        "properties": {
+          "pulse_type": {
+            "const": "sine",
+            "default": "sine",
+            "title": "Pulse Type",
+            "type": "string"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Duration"
+          },
+          "amplitude": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Amplitude"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Amplitude"
+          },
+          "frequency": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Frequency"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Frequency"
+          },
+          "to_frequency": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Frequency"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "To Frequency"
+          }
+        },
+        "required": [
+          "duration",
+          "amplitude",
+          "frequency"
+        ],
+        "title": "SinePulse",
+        "type": "object"
+      },
+      "SquarePulse": {
+        "additionalProperties": false,
+        "properties": {
+          "pulse_type": {
+            "const": "square",
+            "default": "square",
+            "title": "Pulse Type",
+            "type": "string"
+          },
+          "duration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Duration"
+          },
+          "amplitude": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Amplitude"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              }
+            ],
+            "title": "Amplitude"
+          },
+          "rise_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Rise Time"
+          },
+          "fall_time": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "$ref": "#/components/schemas/VariableRef"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Fall Time"
+          }
+        },
+        "required": [
+          "duration",
+          "amplitude"
+        ],
+        "title": "SquarePulse",
+        "type": "object"
+      },
+      "Store": {
+        "additionalProperties": false,
+        "properties": {
+          "op_type": {
+            "const": "store",
+            "default": "store",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "key": {
+            "title": "Key",
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/StoreMode"
+          }
+        },
+        "required": [
+          "key",
+          "source",
+          "mode"
+        ],
+        "title": "Store",
+        "type": "object"
+      },
+      "StoreMode": {
+        "enum": [
+          "last",
+          "average",
+          "count",
+          "trace"
+        ],
+        "title": "StoreMode",
+        "type": "string"
+      },
+      "Threshold": {
+        "additionalProperties": false,
+        "description": "Model to represent a (real) threshold voltage level.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Volts"
+              },
+              {
+                "$ref": "#/components/schemas/Millivolts"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Threshold",
+        "type": "object"
+      },
+      "Time": {
+        "additionalProperties": false,
+        "description": "A model representing time (instant or difference).\n\nThe model can represent time in seconds, milliseconds, microseconds, or nanoseconds,\nwith automatic conversion between the units.\n\nThe storage type for milliseconds is integer, while for other units it is float.\nConversion to nanoseconds is rounded to the nearest integer.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Seconds"
+              },
+              {
+                "$ref": "#/components/schemas/Milliseconds"
+              },
+              {
+                "$ref": "#/components/schemas/Microseconds"
+              },
+              {
+                "$ref": "#/components/schemas/Nanoseconds"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Time",
+        "type": "object"
+      },
+      "Trace": {
+        "additionalProperties": false,
+        "description": "Acquire trace data from the channel with integration.\n\nSimilar to :class:`Record`, but the result is saved into an array variable,\nand it essentially a repeated, continuous record operation.\n\nThe duration is the total time of the trace, the number of records\nis determined by the length of the array variable.\n\nFurther processing may be applied to the result, such as projection to real/imaginary parts,\nsee :class:`Discriminate`.",
+        "properties": {
+          "op_type": {
+            "const": "trace",
+            "default": "trace",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channel": {
+            "$ref": "#/components/schemas/ChannelRef"
+          },
+          "var": {
+            "$ref": "#/components/schemas/VariableRef"
+          },
+          "duration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "integration": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FullIntegration"
+              },
+              {
+                "$ref": "#/components/schemas/DemodIntegration"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Integration"
+          },
+          "time_of_flight": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null
+          }
+        },
+        "required": [
+          "channel",
+          "var",
+          "duration"
+        ],
+        "title": "Trace",
+        "type": "object"
+      },
+      "Turns": {
+        "additionalProperties": false,
+        "description": "Turns as a unit of angle.\n\nA turn is a full rotation, i.e. 360 degrees or 2\u03c0 radians.",
+        "properties": {
+          "turns": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "Turns"
+          }
+        },
+        "required": [
+          "turns"
+        ],
+        "title": "Turns",
+        "type": "object"
+      },
+      "VariableDTypeType": {
+        "enum": [
+          "bool",
+          "int",
+          "float",
+          "complex"
+        ],
+        "type": "string"
+      },
+      "VariableDecl": {
+        "additionalProperties": false,
+        "description": "Variable declaration operation.\n\nVariables must be declared before they can be referred to.\n\nVariable declarations are scoped to the surrounding context and its children.",
+        "properties": {
+          "op_type": {
+            "const": "var_decl",
+            "default": "var_decl",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "name": {
+            "$ref": "#/components/schemas/IdentifierStr"
+          },
+          "dtype": {
+            "$ref": "#/components/schemas/VariableDTypeType"
+          },
+          "shape": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Shape"
+          },
+          "unit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "title": "Unit"
+          }
+        },
+        "required": [
+          "name",
+          "dtype"
+        ],
+        "title": "VariableDecl",
+        "type": "object"
+      },
+      "VariableRef": {
+        "description": "Reference to a variable.\n\nVariables must be declared in the surrounding context or one of its parents.",
+        "properties": {
+          "var": {
+            "$ref": "#/components/schemas/IdentifierStr"
+          }
+        },
+        "required": [
+          "var"
+        ],
+        "title": "VariableRef",
+        "type": "object"
+      },
+      "Voltage": {
+        "additionalProperties": false,
+        "description": "A model representing a real voltage in volts or millivolts.",
+        "properties": {
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Volts"
+              },
+              {
+                "$ref": "#/components/schemas/Millivolts"
+              }
+            ],
+            "title": "Value"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "title": "Voltage",
+        "type": "object"
+      },
+      "Volts": {
+        "additionalProperties": false,
+        "description": "Volts as a unit of voltage (real).",
+        "properties": {
+          "V": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "title": "V"
+          }
+        },
+        "required": [
+          "V"
+        ],
+        "title": "Volts",
+        "type": "object"
+      },
+      "Wait": {
+        "additionalProperties": false,
+        "description": "Add wait of duration on channel(s).\n\nThe wait operations are scheduled to start as soon as possible on each channel.\n\nThe relative timing between channels is not guaranteed.",
+        "properties": {
+          "op_type": {
+            "const": "wait",
+            "default": "wait",
+            "title": "Op Type",
+            "type": "string"
+          },
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/ChannelRef"
+            },
+            "title": "Channels",
+            "type": "array"
+          },
+          "duration": {
+            "$ref": "#/components/schemas/Duration"
+          }
+        },
+        "required": [
+          "channels",
+          "duration"
+        ],
+        "title": "Wait",
+        "type": "object"
+      },
+      "complex_from_tuple": {
+        "anyOf": [
+          {
+            "items": {
+              "type": "number"
+            },
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          {
+            "pattern": "^[+-]?(\\d+(\\.\\d*)?|\\.\\d+)([eE][+-]?\\d+)?[+-](\\d+(\\.\\d*)?|\\.\\d+)([eE][+-]?\\d+)?j$",
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "basic-types",
+      "description": "Basic types like Amplitude, Duration, Frequency, etc."
+    },
+    {
+      "name": "pulse-types",
+      "description": "Pulse type definitions (Square, Sine, Arbitrary, etc.)"
+    },
+    {
+      "name": "channel-ops",
+      "description": "Channel operations (Play, Record, Barrier, etc.)"
+    },
+    {
+      "name": "control-flow",
+      "description": "Control flow operations (Repetition, Iteration, Conditional)"
+    },
+    {
+      "name": "data-ops",
+      "description": "Data operations (Assignment, Arithmetic, etc.)"
+    },
+    {
+      "name": "sequences",
+      "description": "Operation sequences and schedules"
+    },
+    {
+      "name": "reference-types",
+      "description": "Reference types for variables and parameters"
+    },
+    {
+      "name": "units",
+      "description": "Unit types (Seconds, Volts, Hertz, etc.)"
+    }
+  ]
+}

--- a/output/eq1_pulse_openapi.yaml
+++ b/output/eq1_pulse_openapi.yaml
@@ -1,0 +1,1884 @@
+openapi: 3.1.0
+info:
+  title: Equal1 Pulse Models API
+  version: 1.0.0
+  description: OpenAPI schema for Equal1 Pulse library models. This schema defines
+    all the Pydantic models used for pulse sequencing, channel operations, control
+    flow, and data operations.
+components:
+  schemas:
+    Amplitude:
+      additionalProperties: false
+      description: Model to represent the (complex) amplitude of a voltage signal.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/ComplexVolts'
+          - $ref: '#/components/schemas/ComplexMillivolts'
+          title: Value
+      required:
+      - value
+      title: Amplitude
+      type: object
+    Angle:
+      additionalProperties: false
+      description: "A model representing an angle in either degrees, radians, turns\
+        \ or half-turns.\n\nTurns are also known as revolutions or cycles, also :math:`\\\
+        tau=2\\pi` radians or 360\xB0.\nHalf-turns are also known as half-cycles,\
+        \ also :math:`\\pi` radians or 180\xB0."
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Degrees'
+          - $ref: '#/components/schemas/Radians'
+          - $ref: '#/components/schemas/Turns'
+          - $ref: '#/components/schemas/HalfTurns'
+          title: Value
+      required:
+      - value
+      title: Angle
+      type: object
+    ArbitrarySampledPulse:
+      additionalProperties: false
+      description: 'Pulse type that uses arbitrary sampled waveform data.
+
+
+        The amplitude refers to the reference amplitude of the pulse, which is usually
+        the peak amplitude.
+
+        The duration refers to the total duration of the pulse.
+
+        The samples (complex or real) are expected to be normalized between -1 and
+        1, and will be scaled by the amplitude.
+
+        The samples are uniformly distributed over the duration of the pulse, with
+        interpolation applied as needed.'
+      properties:
+        pulse_type:
+          const: arbitrary
+          default: arbitrary
+          title: Pulse Type
+          type: string
+        duration:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Duration
+        amplitude:
+          anyOf:
+          - $ref: '#/components/schemas/Amplitude'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Amplitude
+        samples:
+          anyOf:
+          - $ref: '#/components/schemas/NumpyFloatArray1D'
+          - $ref: '#/components/schemas/NumpyComplexArray1D'
+          title: Samples
+        interpolation:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Interpolation
+        time_points:
+          anyOf:
+          - $ref: '#/components/schemas/NumpyFloatArray1D'
+          - type: 'null'
+          default: null
+      required:
+      - duration
+      - amplitude
+      - samples
+      title: ArbitrarySampledPulse
+      type: object
+    ArithmeticFrozenWrappedValueModel:
+      additionalProperties: false
+      properties:
+        value:
+          title: Value
+      required:
+      - value
+      title: ArithmeticFrozenWrappedValueModel
+      type: object
+    ArithmeticFrozenWrappedValueModel_Union_int__float__:
+      additionalProperties: false
+      properties:
+        value:
+          title: Value
+      required:
+      - value
+      title: ArithmeticFrozenWrappedValueModel[Union[int, float]]
+      type: object
+    ArithmeticFrozenWrappedValueModel_Union_int__float__complex__:
+      additionalProperties: false
+      properties:
+        value:
+          title: Value
+      required:
+      - value
+      title: ArithmeticFrozenWrappedValueModel[Union[int, float, complex]]
+      type: object
+    Barrier:
+      additionalProperties: false
+      description: 'Synchronize channels.
+
+
+        The barrier operation causes channels to wait until all channels have reached
+        the barrier.'
+      properties:
+        op_type:
+          const: barrier
+          default: barrier
+          title: Op Type
+          type: string
+        channels:
+          items:
+            $ref: '#/components/schemas/ChannelRef'
+          title: Channels
+          type: array
+      required:
+      - channels
+      title: Barrier
+      type: object
+    ChannelOp:
+      discriminator:
+        mapping:
+          barrier: '#/components/schemas/Barrier'
+          dc_comp: '#/components/schemas/CompensateDC'
+          play: '#/components/schemas/Play'
+          record: '#/components/schemas/Record'
+          set_frequency: '#/components/schemas/SetFrequency'
+          set_phase: '#/components/schemas/SetPhase'
+          shift_frequency: '#/components/schemas/ShiftFrequency'
+          shift_phase: '#/components/schemas/ShiftPhase'
+          trace: '#/components/schemas/Trace'
+          wait: '#/components/schemas/Wait'
+        propertyName: op_type
+      oneOf:
+      - $ref: '#/components/schemas/Play'
+      - $ref: '#/components/schemas/Wait'
+      - $ref: '#/components/schemas/Barrier'
+      - $ref: '#/components/schemas/SetFrequency'
+      - $ref: '#/components/schemas/ShiftFrequency'
+      - $ref: '#/components/schemas/SetPhase'
+      - $ref: '#/components/schemas/ShiftPhase'
+      - $ref: '#/components/schemas/Record'
+      - $ref: '#/components/schemas/Trace'
+      - $ref: '#/components/schemas/CompensateDC'
+    ChannelOpBase:
+      additionalProperties: false
+      description: Base class for operations involving a single channel.
+      properties:
+        op_type:
+          title: Op Type
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+      required:
+      - op_type
+      - channel
+      title: ChannelOpBase
+      type: object
+    ChannelRef:
+      description: 'Reference to a channel.
+
+
+        Channels are defined in the target''s hardware configuration.'
+      properties:
+        channel:
+          $ref: '#/components/schemas/IdentifierStr'
+      required:
+      - channel
+      title: ChannelRef
+      type: object
+    ChannelsOpBase:
+      additionalProperties: false
+      description: Base class for operations involving multiple channels.
+      properties:
+        op_type:
+          title: Op Type
+        channels:
+          items:
+            $ref: '#/components/schemas/ChannelRef'
+          title: Channels
+          type: array
+      required:
+      - op_type
+      - channels
+      title: ChannelsOpBase
+      type: object
+    ComparisonMode:
+      enum:
+      - '>='
+      - '>'
+      - <=
+      - <
+      title: ComparisonMode
+      type: string
+    CompensateDC:
+      additionalProperties: false
+      description: 'Apply DC offset compensation to the channel.
+
+
+        A square wave of specified duration is played on the channel. The amplitude
+        of the wave is calculated to
+
+        result in a zero average value when integrated over the duration since the
+        laste reset.
+
+
+        If ``null``/:obj:`None` duration is specified, the accumulated value is reset
+        to zero, without
+
+        playing a compensation pulse.
+
+
+        If ``max_amp`` is specified, the amplitude of the compensation pulse is limited
+        to that value.
+
+        If the amplitude is calculated to be higher, the pulse area is subtracted
+        from the accumulated value,
+
+        leaving the possibility to compensate the rest in the following operations.
+
+
+        If ``rise_time`` and ``fall_time`` are specified, they define the duration
+        of linear ramps
+
+        at the beginning and end of the compensation pulse. The ramps are included
+        in the area calculation.
+
+        The rise and fall times are also included in the total duration of the compensation
+        pulse.'
+      properties:
+        op_type:
+          const: dc_comp
+          default: dc_comp
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        duration:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          title: Duration
+        max_amp:
+          anyOf:
+          - $ref: '#/components/schemas/Magnitude'
+          - type: 'null'
+          default: null
+        rise_time:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+          title: Rise Time
+        fall_time:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+          title: Fall Time
+      required:
+      - channel
+      - duration
+      title: CompensateDC
+      type: object
+    ComplexMillivolts:
+      additionalProperties: false
+      description: Millivolts as a unit of voltage (real + imaginary).
+      properties:
+        mV:
+          anyOf:
+          - type: integer
+          - type: number
+          - $ref: '#/components/schemas/complex_from_tuple'
+          title: Mv
+      required:
+      - mV
+      title: ComplexMillivolts
+      type: object
+    ComplexToRealProjectionMode:
+      enum:
+      - real
+      - imag
+      - abs
+      - phase
+      title: ComplexToRealProjectionMode
+      type: string
+    ComplexVoltage:
+      additionalProperties: false
+      description: 'A model representing a complex voltage in volts or millivolts.
+
+
+        Complex voltages are used to represent both amplitude and phase information,
+
+        and are used with with mixing or demodulation operations.'
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/ComplexVolts'
+          - $ref: '#/components/schemas/ComplexMillivolts'
+          title: Value
+      required:
+      - value
+      title: ComplexVoltage
+      type: object
+    ComplexVolts:
+      additionalProperties: false
+      description: Volts as a unit of voltage (real + imaginary).
+      properties:
+        V:
+          anyOf:
+          - type: integer
+          - type: number
+          - $ref: '#/components/schemas/complex_from_tuple'
+          title: V
+      required:
+      - V
+      title: ComplexVolts
+      type: object
+    Conditional:
+      additionalProperties: false
+      description: 'Represents a conditional sequence of operations.
+
+
+        :ivar op_type: Operation type, always "if"
+
+        :ivar var: The variable reference for the condition.
+
+        :ivar body: The sequence of operations to execute if the condition is met'
+      properties:
+        op_type:
+          const: if
+          default: if
+          title: Op Type
+          type: string
+        var:
+          $ref: '#/components/schemas/VariableRef'
+        body:
+          $ref: '#/components/schemas/OpSequence'
+      required:
+      - var
+      - body
+      title: Conditional
+      type: object
+    ConditionalBase_OpSequence_:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: if
+          default: if
+          title: Op Type
+          type: string
+        var:
+          $ref: '#/components/schemas/VariableRef'
+        body:
+          $ref: '#/components/schemas/OpSequence'
+      required:
+      - var
+      - body
+      title: ConditionalBase[OpSequence]
+      type: object
+    ConditionalBase_Schedule_:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: if
+          default: if
+          title: Op Type
+          type: string
+        var:
+          $ref: '#/components/schemas/VariableRef'
+        body:
+          $ref: '#/components/schemas/Schedule'
+      required:
+      - var
+      - body
+      title: ConditionalBase[Schedule]
+      type: object
+    DataOpBase:
+      additionalProperties: false
+      properties:
+        op_type:
+          title: Op Type
+      required:
+      - op_type
+      title: DataOpBase
+      type: object
+    Degrees:
+      additionalProperties: false
+      description: Degrees as a unit of angle.
+      properties:
+        deg:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Deg
+      required:
+      - deg
+      title: Degrees
+      type: object
+    DemodIntegration:
+      additionalProperties: false
+      description: 'Demodulation integration of measured values.
+
+
+        The demodulation operation will multiply the measured signal with
+
+        the channels'' output signal before integration.
+
+        If scale_cos/scale_sin are specified they can be used to scale and "flip"
+        the real/imaginary parts of the result.
+
+
+        An optional phase may be applied to rotate the result.'
+      properties:
+        integration_type:
+          const: demod
+          default: demod
+          title: Integration Type
+          type: string
+        phase:
+          anyOf:
+          - $ref: '#/components/schemas/Phase'
+          - type: 'null'
+          default: null
+        scale_cos:
+          default: 1
+          title: Scale Cos
+          type: number
+        scale_sin:
+          default: 1
+          title: Scale Sin
+          type: number
+      title: DemodIntegration
+      type: object
+    DiscriminableOp:
+      discriminator:
+        mapping:
+          barrier: '#/components/schemas/ChannelOp'
+          dc_comp: '#/components/schemas/ChannelOp'
+          discriminate: '#/components/schemas/Discriminate'
+          for: '#/components/schemas/Iteration'
+          if: '#/components/schemas/Conditional'
+          play: '#/components/schemas/ChannelOp'
+          pulse_decl: '#/components/schemas/PulseDecl'
+          record: '#/components/schemas/ChannelOp'
+          repeat: '#/components/schemas/Repetition'
+          set_frequency: '#/components/schemas/ChannelOp'
+          set_phase: '#/components/schemas/ChannelOp'
+          shift_frequency: '#/components/schemas/ChannelOp'
+          shift_phase: '#/components/schemas/ChannelOp'
+          store: '#/components/schemas/Store'
+          trace: '#/components/schemas/ChannelOp'
+          var_decl: '#/components/schemas/VariableDecl'
+          wait: '#/components/schemas/ChannelOp'
+        propertyName: op_type
+      oneOf:
+      - $ref: '#/components/schemas/ChannelOp'
+      - $ref: '#/components/schemas/VariableDecl'
+      - $ref: '#/components/schemas/PulseDecl'
+      - $ref: '#/components/schemas/Discriminate'
+      - $ref: '#/components/schemas/Store'
+      - $ref: '#/components/schemas/Repetition'
+      - $ref: '#/components/schemas/Iteration'
+      - $ref: '#/components/schemas/Conditional'
+    DiscriminableSchedulableOp:
+      discriminator:
+        mapping:
+          barrier: '#/components/schemas/ChannelOp'
+          dc_comp: '#/components/schemas/ChannelOp'
+          discriminate: '#/components/schemas/Discriminate'
+          for: '#/components/schemas/SchedIteration'
+          if: '#/components/schemas/SchedConditional'
+          play: '#/components/schemas/ChannelOp'
+          pulse_decl: '#/components/schemas/PulseDecl'
+          record: '#/components/schemas/ChannelOp'
+          repeat: '#/components/schemas/SchedRepetition'
+          set_frequency: '#/components/schemas/ChannelOp'
+          set_phase: '#/components/schemas/ChannelOp'
+          shift_frequency: '#/components/schemas/ChannelOp'
+          shift_phase: '#/components/schemas/ChannelOp'
+          store: '#/components/schemas/Store'
+          trace: '#/components/schemas/ChannelOp'
+          var_decl: '#/components/schemas/VariableDecl'
+          wait: '#/components/schemas/ChannelOp'
+        propertyName: op_type
+      oneOf:
+      - $ref: '#/components/schemas/ChannelOp'
+      - $ref: '#/components/schemas/VariableDecl'
+      - $ref: '#/components/schemas/PulseDecl'
+      - $ref: '#/components/schemas/Discriminate'
+      - $ref: '#/components/schemas/Store'
+      - $ref: '#/components/schemas/SchedRepetition'
+      - $ref: '#/components/schemas/SchedIteration'
+      - $ref: '#/components/schemas/SchedConditional'
+    Discriminate:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: discriminate
+          default: discriminate
+          title: Op Type
+          type: string
+        target:
+          $ref: '#/components/schemas/VariableRef'
+        source:
+          $ref: '#/components/schemas/VariableRef'
+        threshold:
+          $ref: '#/components/schemas/Threshold'
+        rotation:
+          $ref: '#/components/schemas/Phase'
+          default:
+            rad: 0.0
+        compare:
+          $ref: '#/components/schemas/ComparisonMode'
+          default: '>='
+        project:
+          $ref: '#/components/schemas/ComplexToRealProjectionMode'
+          default: real
+      required:
+      - target
+      - source
+      - threshold
+      title: Discriminate
+      type: object
+    Duration:
+      additionalProperties: false
+      description: Special case of non-negative Time representing a duration.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Seconds'
+          - $ref: '#/components/schemas/Milliseconds'
+          - $ref: '#/components/schemas/Microseconds'
+          - $ref: '#/components/schemas/Nanoseconds'
+          title: Value
+      required:
+      - value
+      title: Duration
+      type: object
+    ExternalPulse:
+      additionalProperties: false
+      description: 'Pulse type that references an externally defined pulse function.
+
+
+        The amplitude refers to the reference amplitude of the pulse, which is usually
+        the peak amplitude.
+
+        The duration refers to the total duration of the pulse.
+
+
+        The pulse function is expected to be defined elsewhere, such as in a pulse
+        library or a hardware definition.'
+      properties:
+        pulse_type:
+          const: external
+          default: external
+          title: Pulse Type
+          type: string
+        duration:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Duration
+        amplitude:
+          anyOf:
+          - $ref: '#/components/schemas/Amplitude'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Amplitude
+        function:
+          $ref: '#/components/schemas/FullyQualifiedIdentifier'
+        params:
+          anyOf:
+          - additionalProperties:
+              $ref: '#/components/schemas/PulseParamValue'
+            type: object
+          - type: 'null'
+          default: null
+          title: Params
+      required:
+      - duration
+      - amplitude
+      - function
+      title: ExternalPulse
+      type: object
+    Frequency:
+      additionalProperties: false
+      description: A model representing a frequency in Hertz, Kilohertz, Megahertz,
+        or Gigahertz.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Hertz'
+          - $ref: '#/components/schemas/Kilohertz'
+          - $ref: '#/components/schemas/Megahertz'
+          - $ref: '#/components/schemas/Gigahertz'
+          title: Value
+      required:
+      - value
+      title: Frequency
+      type: object
+    FullIntegration:
+      additionalProperties: false
+      description: Full summation of measured values.
+      properties:
+        integration_type:
+          const: full
+          default: full
+          title: Integration Type
+          type: string
+      title: FullIntegration
+      type: object
+    FullyQualifiedIdentifier:
+      type: string
+    Gigahertz:
+      additionalProperties: false
+      description: Gigahertz as a unit of frequency.
+      properties:
+        GHz:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Ghz
+      required:
+      - GHz
+      title: Gigahertz
+      type: object
+    HalfTurns:
+      additionalProperties: false
+      description: "Half turns as a unit of angle.\n\nA half turn is half a full rotation,\
+        \ i.e. 180 degrees or \u03C0 radians."
+      properties:
+        half_turns:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Half Turns
+      required:
+      - half_turns
+      title: HalfTurns
+      type: object
+    Hertz:
+      additionalProperties: false
+      description: Hertz as a unit of frequency.
+      properties:
+        Hz:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Hz
+      required:
+      - Hz
+      title: Hertz
+      type: object
+    IdentifierStr:
+      type: string
+    IntegrationType:
+      additionalProperties: false
+      description: Base class for different types of integration operations.
+      properties:
+        integration_type:
+          title: Integration Type
+      required:
+      - integration_type
+      title: IntegrationType
+      type: object
+    IterableSequence:
+      anyOf:
+      - $ref: '#/components/schemas/LinSpace'
+      - $ref: '#/components/schemas/Range'
+      - items:
+          type: string
+        type: array
+      - $ref: '#/components/schemas/NumpyIterableArray'
+    Iteration:
+      additionalProperties: false
+      description: 'Represents an iteration over a sequence of operations.
+
+
+        :ivar op_type: Operation type, always "for"
+
+        :ivar var: The variable reference for the iterated value.
+
+        :ivar items: The range or array over which to iterate.
+
+        :ivar body: The sequence of operations to execute in each iteration'
+      properties:
+        op_type:
+          const: for
+          default: for
+          title: Op Type
+          type: string
+        var:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/VariableRef'
+            type: array
+          - $ref: '#/components/schemas/VariableRef'
+          title: Var
+        items:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/IterableSequence'
+            type: array
+          - $ref: '#/components/schemas/IterableSequence'
+          title: Items
+        body:
+          $ref: '#/components/schemas/OpSequence'
+      required:
+      - var
+      - items
+      - body
+      title: Iteration
+      type: object
+    IterationBase_OpSequence_:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: for
+          default: for
+          title: Op Type
+          type: string
+        var:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/VariableRef'
+            type: array
+          - $ref: '#/components/schemas/VariableRef'
+          title: Var
+        items:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/IterableSequence'
+            type: array
+          - $ref: '#/components/schemas/IterableSequence'
+          title: Items
+        body:
+          $ref: '#/components/schemas/OpSequence'
+      required:
+      - var
+      - items
+      - body
+      title: IterationBase[OpSequence]
+      type: object
+    IterationBase_Schedule_:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: for
+          default: for
+          title: Op Type
+          type: string
+        var:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/VariableRef'
+            type: array
+          - $ref: '#/components/schemas/VariableRef'
+          title: Var
+        items:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/IterableSequence'
+            type: array
+          - $ref: '#/components/schemas/IterableSequence'
+          title: Items
+        body:
+          $ref: '#/components/schemas/Schedule'
+      required:
+      - var
+      - items
+      - body
+      title: IterationBase[Schedule]
+      type: object
+    Kilohertz:
+      additionalProperties: false
+      description: Kilohertz as a unit of frequency.
+      properties:
+        kHz:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Khz
+      required:
+      - kHz
+      title: Kilohertz
+      type: object
+    LinSpace:
+      additionalProperties: false
+      description: 'Represents a linear space between two values.
+
+
+        :ivar start: Starting value (can be real or complex)
+
+        :ivar stop: Ending value (can be real or complex)
+
+        :ivar num: Number of points in the space, including endpoints.'
+      properties:
+        start:
+          anyOf:
+          - type: integer
+          - type: number
+          - type: string
+          title: Start
+        stop:
+          anyOf:
+          - type: integer
+          - type: number
+          - type: string
+          title: Stop
+        num:
+          minimum: 1
+          title: Num
+          type: integer
+      required:
+      - start
+      - stop
+      - num
+      title: LinSpace
+      type: object
+    Magnitude:
+      additionalProperties: false
+      description: Special case of non-negative real Voltage representing a maximum
+        amplitude.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Volts'
+          - $ref: '#/components/schemas/Millivolts'
+          title: Value
+      required:
+      - value
+      title: Magnitude
+      type: object
+    Megahertz:
+      additionalProperties: false
+      description: Megahertz as a unit of frequency.
+      properties:
+        MHz:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Mhz
+      required:
+      - MHz
+      title: Megahertz
+      type: object
+    Microseconds:
+      additionalProperties: false
+      description: Microseconds as a unit of time.
+      properties:
+        us:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Us
+      required:
+      - us
+      title: Microseconds
+      type: object
+    Milliseconds:
+      additionalProperties: false
+      description: Milliseconds as a unit of time.
+      properties:
+        ms:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Ms
+      required:
+      - ms
+      title: Milliseconds
+      type: object
+    Millivolts:
+      additionalProperties: false
+      description: Millivolts as a unit of voltage (real).
+      properties:
+        mV:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Mv
+      required:
+      - mV
+      title: Millivolts
+      type: object
+    Nanoseconds:
+      additionalProperties: false
+      description: Nanoseconds as a unit of time.
+      properties:
+        ns:
+          title: Ns
+          type: integer
+      required:
+      - ns
+      title: Nanoseconds
+      type: object
+    NumpyComplexArray1D:
+      items:
+        items:
+          type: number
+        maxItems: 2
+        minItems: 2
+        type: array
+      type: array
+    NumpyFloatArray1D:
+      items:
+        type: number
+      type: array
+    NumpyIntArray1D:
+      items:
+        type: integer
+      type: array
+    NumpyIterableArray:
+      anyOf:
+      - $ref: '#/components/schemas/NumpyIntArray1D'
+      - $ref: '#/components/schemas/NumpyFloatArray1D'
+      - $ref: '#/components/schemas/NumpyComplexArray1D'
+    OpSequence:
+      additionalProperties: false
+      description: 'A sequence of operation items that can be serialized as a list.
+
+
+        This class represents an ordered collection of operation sequence items that
+
+        will be serialized as a list when converted to JSON or other formats.
+
+
+        :ivar items: List of operation sequence items'
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/OpSequenceItem'
+          title: Items
+          type: array
+      required:
+      - items
+      title: OpSequence
+      type: object
+    OpSequenceItem:
+      anyOf:
+      - $ref: '#/components/schemas/DiscriminableOp'
+      - $ref: '#/components/schemas/OpSequence'
+    Phase:
+      additionalProperties: false
+      description: Special case of Angle where the value represents a phase angle.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Degrees'
+          - $ref: '#/components/schemas/Radians'
+          - $ref: '#/components/schemas/Turns'
+          - $ref: '#/components/schemas/HalfTurns'
+          title: Value
+      required:
+      - value
+      title: Phase
+      type: object
+    Play:
+      additionalProperties: false
+      description: Play a pulse on a channel.
+      properties:
+        op_type:
+          const: play
+          default: play
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        pulse:
+          anyOf:
+          - $ref: '#/components/schemas/PulseType'
+          - $ref: '#/components/schemas/PulseRef'
+          title: Pulse
+        scale_amp:
+          anyOf:
+          - type: number
+          - type: string
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+          title: Scale Amp
+        cond:
+          anyOf:
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+      required:
+      - channel
+      - pulse
+      title: Play
+      type: object
+    PulseDecl:
+      additionalProperties: false
+      description: 'Pulse declaration operation.
+
+
+        Pulses must be declared before they can be referred to.
+
+        Pulse declarations are scoped to the surrounding context and its children.'
+      properties:
+        op_type:
+          const: pulse_decl
+          default: pulse_decl
+          title: Op Type
+          type: string
+        name:
+          title: Name
+          type: string
+        pulse:
+          $ref: '#/components/schemas/PulseType'
+      required:
+      - name
+      - pulse
+      title: PulseDecl
+      type: object
+    PulseParamScalarValue:
+      anyOf:
+      - type: number
+      - type: integer
+      - type: string
+    PulseParamValue:
+      anyOf:
+      - $ref: '#/components/schemas/Amplitude'
+      - $ref: '#/components/schemas/Duration'
+      - $ref: '#/components/schemas/Frequency'
+      - $ref: '#/components/schemas/VariableRef'
+      - $ref: '#/components/schemas/PulseParamScalarValue'
+    PulseRef:
+      description: 'Reference to a pulse.
+
+
+        Pulses must be declared in the surrounding context or one of its parents.'
+      properties:
+        pulse_name:
+          $ref: '#/components/schemas/IdentifierStr'
+      required:
+      - pulse_name
+      title: PulseRef
+      type: object
+    PulseType:
+      discriminator:
+        mapping:
+          arbitrary: '#/components/schemas/ArbitrarySampledPulse'
+          external: '#/components/schemas/ExternalPulse'
+          sine: '#/components/schemas/SinePulse'
+          square: '#/components/schemas/SquarePulse'
+        propertyName: pulse_type
+      oneOf:
+      - $ref: '#/components/schemas/SquarePulse'
+      - $ref: '#/components/schemas/SinePulse'
+      - $ref: '#/components/schemas/ExternalPulse'
+      - $ref: '#/components/schemas/ArbitrarySampledPulse'
+    Radians:
+      additionalProperties: false
+      description: Radians as a unit of angle.
+      properties:
+        rad:
+          title: Rad
+          type: number
+      required:
+      - rad
+      title: Radians
+      type: object
+    Range:
+      additionalProperties: false
+      description: 'Represents a range of values with a start, stop, and step.
+
+
+        The step can only be zero if the start and stop values are equal. Otherwise,
+
+        the step must evenly divide the difference between the start and stop values.
+
+
+        In case of complex numbers, the the difference must be an integral multiple
+        of the step.
+
+        The sign of the step is adjusted to ensure the stop value is reached.
+
+
+        The stop point is always included in the range.
+
+
+        :ivar start: Starting value (can be real or complex)
+
+        :ivar stop: Ending value (can be real or complex) included in the range
+
+        :ivar step: Step size (can be real or complex)'
+      properties:
+        start:
+          anyOf:
+          - type: integer
+          - type: number
+          - type: string
+          title: Start
+        stop:
+          anyOf:
+          - type: integer
+          - type: number
+          - type: string
+          title: Stop
+        step:
+          anyOf:
+          - type: integer
+          - type: number
+          - $ref: '#/components/schemas/complex_from_tuple'
+          title: Step
+      required:
+      - start
+      - stop
+      - step
+      title: Range
+      type: object
+    Record:
+      additionalProperties: false
+      description: 'Acquire scalar data from the channel with integration.
+
+
+        The integration type can be either "full" or "demod".
+
+        Full integration is a simple accumulation of the signal.
+
+        Demod integration is a complex multiplication of the signal with the channel''s
+
+        frequency and phase followed by accumulation.
+
+
+        The result of the integration is saved into a scalar (complex) variable.
+
+
+        Further processing may be applied to the result, such as projection to real/imaginary
+        parts,
+
+        see :class:`Discriminate`.'
+      properties:
+        op_type:
+          const: record
+          default: record
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        var:
+          $ref: '#/components/schemas/VariableRef'
+        duration:
+          $ref: '#/components/schemas/Duration'
+        integration:
+          anyOf:
+          - $ref: '#/components/schemas/FullIntegration'
+          - $ref: '#/components/schemas/DemodIntegration'
+          title: Integration
+        time_of_flight:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - type: 'null'
+          default: null
+      required:
+      - channel
+      - var
+      - duration
+      - integration
+      title: Record
+      type: object
+    RefPt:
+      description: 'An enumeration of reference points for Schedulables.
+
+
+        These represent the alignment points of the existing and the newly inserted
+        schedulable.'
+      enum:
+      - start
+      - end
+      - center
+      title: RefPt
+      type: string
+    Reference:
+      description: 'Base class for all symbolic references.
+
+
+        Descendants must only define a single field (the reference name), which is
+        serialized directly.'
+      properties: {}
+      title: Reference
+      type: object
+    RelTime:
+      additionalProperties: false
+      description: A subclass of Time representing relative time between Schedulables.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Seconds'
+          - $ref: '#/components/schemas/Milliseconds'
+          - $ref: '#/components/schemas/Microseconds'
+          - $ref: '#/components/schemas/Nanoseconds'
+          title: Value
+      required:
+      - value
+      title: RelTime
+      type: object
+    Repetition:
+      additionalProperties: false
+      description: 'Represents a repeated sequence of operations.
+
+
+        :ivar op_type: Operation type, always "repeat"
+
+        :ivar count: Number of times to repeat the sequence
+
+        :ivar body: The sequence of operations to repeat'
+      properties:
+        op_type:
+          const: repeat
+          default: repeat
+          title: Op Type
+          type: string
+        count:
+          minimum: 0
+          title: Count
+          type: integer
+        body:
+          $ref: '#/components/schemas/OpSequence'
+      required:
+      - count
+      - body
+      title: Repetition
+      type: object
+    RepetitionBase_OpSequence_:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: repeat
+          default: repeat
+          title: Op Type
+          type: string
+        count:
+          minimum: 0
+          title: Count
+          type: integer
+        body:
+          $ref: '#/components/schemas/OpSequence'
+      required:
+      - count
+      - body
+      title: RepetitionBase[OpSequence]
+      type: object
+    RepetitionBase_Schedule_:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: repeat
+          default: repeat
+          title: Op Type
+          type: string
+        count:
+          minimum: 0
+          title: Count
+          type: integer
+        body:
+          $ref: '#/components/schemas/Schedule'
+      required:
+      - count
+      - body
+      title: RepetitionBase[Schedule]
+      type: object
+    SchedConditional:
+      additionalProperties: false
+      description: A class representing a conditional embedded in a schedule.
+      properties:
+        op_type:
+          const: if
+          default: if
+          title: Op Type
+          type: string
+        var:
+          $ref: '#/components/schemas/VariableRef'
+        body:
+          $ref: '#/components/schemas/Schedule'
+      required:
+      - var
+      - body
+      title: SchedConditional
+      type: object
+    SchedIteration:
+      additionalProperties: false
+      description: A class representing an iterated schedule in a schedule.
+      properties:
+        op_type:
+          const: for
+          default: for
+          title: Op Type
+          type: string
+        var:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/VariableRef'
+            type: array
+          - $ref: '#/components/schemas/VariableRef'
+          title: Var
+        items:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/IterableSequence'
+            type: array
+          - $ref: '#/components/schemas/IterableSequence'
+          title: Items
+        body:
+          $ref: '#/components/schemas/Schedule'
+      required:
+      - var
+      - items
+      - body
+      title: SchedIteration
+      type: object
+    SchedRepetition:
+      additionalProperties: false
+      description: A class representing repeated schedule embedded in a schedule.
+      properties:
+        op_type:
+          const: repeat
+          default: repeat
+          title: Op Type
+          type: string
+        count:
+          minimum: 0
+          title: Count
+          type: integer
+        body:
+          $ref: '#/components/schemas/Schedule'
+      required:
+      - count
+      - body
+      title: SchedRepetition
+      type: object
+    Schedulable:
+      anyOf:
+      - $ref: '#/components/schemas/DiscriminableSchedulableOp'
+      - $ref: '#/components/schemas/Schedule'
+    Schedule:
+      additionalProperties: false
+      description: A collection of scheduled operations.
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/ScheduledOperation'
+          title: Items
+          type: array
+      required:
+      - items
+      title: Schedule
+      type: object
+    ScheduledOperation:
+      additionalProperties: false
+      description: 'A class representing a scheduled operation with timing and reference
+        information.
+
+
+        :param name: Optional name for the operation
+
+        :param rel_time: Relative time from the reference point
+
+        :param ref_op: Name of the reference operation
+
+        :param ref_pt: Reference point on the reference operation
+
+        :param ref_pt_new: Reference point on the new operation
+
+        :param op: The schedulable operation'
+      properties:
+        name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Name
+        rel_time:
+          anyOf:
+          - $ref: '#/components/schemas/RelTime'
+          - type: 'null'
+          default: null
+        ref_op:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Ref Op
+        ref_pt:
+          anyOf:
+          - $ref: '#/components/schemas/RefPt'
+          - type: 'null'
+          default: null
+        ref_pt_new:
+          anyOf:
+          - $ref: '#/components/schemas/RefPt'
+          - type: 'null'
+          default: null
+        op:
+          $ref: '#/components/schemas/Schedulable'
+      required:
+      - op
+      title: ScheduledOperation
+      type: object
+    Seconds:
+      additionalProperties: false
+      description: Seconds as a unit of time.
+      properties:
+        s:
+          title: S
+          type: number
+      required:
+      - s
+      title: Seconds
+      type: object
+    SequenceBase_OpSequenceItem_:
+      additionalProperties: false
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/OpSequenceItem'
+          title: Items
+          type: array
+      required:
+      - items
+      title: SequenceBase[OpSequenceItem]
+      type: object
+    SequenceBase_ScheduledOperation_:
+      additionalProperties: false
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/ScheduledOperation'
+          title: Items
+          type: array
+      required:
+      - items
+      title: SequenceBase[ScheduledOperation]
+      type: object
+    SetFrequency:
+      additionalProperties: false
+      description: Set the frequency of a channel.
+      properties:
+        op_type:
+          const: set_frequency
+          default: set_frequency
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        frequency:
+          anyOf:
+          - $ref: '#/components/schemas/Frequency'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Frequency
+      required:
+      - channel
+      - frequency
+      title: SetFrequency
+      type: object
+    SetPhase:
+      additionalProperties: false
+      description: Set the phase of a channel.
+      properties:
+        op_type:
+          const: set_phase
+          default: set_phase
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        phase:
+          anyOf:
+          - $ref: '#/components/schemas/Phase'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Phase
+      required:
+      - channel
+      - phase
+      title: SetPhase
+      type: object
+    ShiftFrequency:
+      additionalProperties: false
+      description: Add a frequency shift to the channel frequency.
+      properties:
+        op_type:
+          const: shift_frequency
+          default: shift_frequency
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        frequency:
+          anyOf:
+          - $ref: '#/components/schemas/Frequency'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Frequency
+      required:
+      - channel
+      - frequency
+      title: ShiftFrequency
+      type: object
+    ShiftPhase:
+      additionalProperties: false
+      description: Add a phase shift to the channel phase.
+      properties:
+        op_type:
+          const: shift_phase
+          default: shift_phase
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        phase:
+          anyOf:
+          - $ref: '#/components/schemas/Phase'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Phase
+      required:
+      - channel
+      - phase
+      title: ShiftPhase
+      type: object
+    SinePulse:
+      additionalProperties: false
+      properties:
+        pulse_type:
+          const: sine
+          default: sine
+          title: Pulse Type
+          type: string
+        duration:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Duration
+        amplitude:
+          anyOf:
+          - $ref: '#/components/schemas/Amplitude'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Amplitude
+        frequency:
+          anyOf:
+          - $ref: '#/components/schemas/Frequency'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Frequency
+        to_frequency:
+          anyOf:
+          - $ref: '#/components/schemas/Frequency'
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+          title: To Frequency
+      required:
+      - duration
+      - amplitude
+      - frequency
+      title: SinePulse
+      type: object
+    SquarePulse:
+      additionalProperties: false
+      properties:
+        pulse_type:
+          const: square
+          default: square
+          title: Pulse Type
+          type: string
+        duration:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Duration
+        amplitude:
+          anyOf:
+          - $ref: '#/components/schemas/Amplitude'
+          - $ref: '#/components/schemas/VariableRef'
+          title: Amplitude
+        rise_time:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+          title: Rise Time
+        fall_time:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - $ref: '#/components/schemas/VariableRef'
+          - type: 'null'
+          default: null
+          title: Fall Time
+      required:
+      - duration
+      - amplitude
+      title: SquarePulse
+      type: object
+    Store:
+      additionalProperties: false
+      properties:
+        op_type:
+          const: store
+          default: store
+          title: Op Type
+          type: string
+        key:
+          title: Key
+          type: string
+        source:
+          $ref: '#/components/schemas/VariableRef'
+        mode:
+          $ref: '#/components/schemas/StoreMode'
+      required:
+      - key
+      - source
+      - mode
+      title: Store
+      type: object
+    StoreMode:
+      enum:
+      - last
+      - average
+      - count
+      - trace
+      title: StoreMode
+      type: string
+    Threshold:
+      additionalProperties: false
+      description: Model to represent a (real) threshold voltage level.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Volts'
+          - $ref: '#/components/schemas/Millivolts'
+          title: Value
+      required:
+      - value
+      title: Threshold
+      type: object
+    Time:
+      additionalProperties: false
+      description: 'A model representing time (instant or difference).
+
+
+        The model can represent time in seconds, milliseconds, microseconds, or nanoseconds,
+
+        with automatic conversion between the units.
+
+
+        The storage type for milliseconds is integer, while for other units it is
+        float.
+
+        Conversion to nanoseconds is rounded to the nearest integer.'
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Seconds'
+          - $ref: '#/components/schemas/Milliseconds'
+          - $ref: '#/components/schemas/Microseconds'
+          - $ref: '#/components/schemas/Nanoseconds'
+          title: Value
+      required:
+      - value
+      title: Time
+      type: object
+    Trace:
+      additionalProperties: false
+      description: 'Acquire trace data from the channel with integration.
+
+
+        Similar to :class:`Record`, but the result is saved into an array variable,
+
+        and it essentially a repeated, continuous record operation.
+
+
+        The duration is the total time of the trace, the number of records
+
+        is determined by the length of the array variable.
+
+
+        Further processing may be applied to the result, such as projection to real/imaginary
+        parts,
+
+        see :class:`Discriminate`.'
+      properties:
+        op_type:
+          const: trace
+          default: trace
+          title: Op Type
+          type: string
+        channel:
+          $ref: '#/components/schemas/ChannelRef'
+        var:
+          $ref: '#/components/schemas/VariableRef'
+        duration:
+          $ref: '#/components/schemas/Duration'
+        integration:
+          anyOf:
+          - $ref: '#/components/schemas/FullIntegration'
+          - $ref: '#/components/schemas/DemodIntegration'
+          - type: 'null'
+          default: null
+          title: Integration
+        time_of_flight:
+          anyOf:
+          - $ref: '#/components/schemas/Duration'
+          - type: 'null'
+          default: null
+      required:
+      - channel
+      - var
+      - duration
+      title: Trace
+      type: object
+    Turns:
+      additionalProperties: false
+      description: "Turns as a unit of angle.\n\nA turn is a full rotation, i.e. 360\
+        \ degrees or 2\u03C0 radians."
+      properties:
+        turns:
+          anyOf:
+          - type: integer
+          - type: number
+          title: Turns
+      required:
+      - turns
+      title: Turns
+      type: object
+    VariableDTypeType:
+      enum:
+      - bool
+      - int
+      - float
+      - complex
+      type: string
+    VariableDecl:
+      additionalProperties: false
+      description: 'Variable declaration operation.
+
+
+        Variables must be declared before they can be referred to.
+
+
+        Variable declarations are scoped to the surrounding context and its children.'
+      properties:
+        op_type:
+          const: var_decl
+          default: var_decl
+          title: Op Type
+          type: string
+        name:
+          $ref: '#/components/schemas/IdentifierStr'
+        dtype:
+          $ref: '#/components/schemas/VariableDTypeType'
+        shape:
+          anyOf:
+          - items:
+              type: integer
+            type: array
+          - type: 'null'
+          default: null
+          title: Shape
+        unit:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Unit
+      required:
+      - name
+      - dtype
+      title: VariableDecl
+      type: object
+    VariableRef:
+      description: 'Reference to a variable.
+
+
+        Variables must be declared in the surrounding context or one of its parents.'
+      properties:
+        var:
+          $ref: '#/components/schemas/IdentifierStr'
+      required:
+      - var
+      title: VariableRef
+      type: object
+    Voltage:
+      additionalProperties: false
+      description: A model representing a real voltage in volts or millivolts.
+      properties:
+        value:
+          anyOf:
+          - $ref: '#/components/schemas/Volts'
+          - $ref: '#/components/schemas/Millivolts'
+          title: Value
+      required:
+      - value
+      title: Voltage
+      type: object
+    Volts:
+      additionalProperties: false
+      description: Volts as a unit of voltage (real).
+      properties:
+        V:
+          anyOf:
+          - type: integer
+          - type: number
+          title: V
+      required:
+      - V
+      title: Volts
+      type: object
+    Wait:
+      additionalProperties: false
+      description: 'Add wait of duration on channel(s).
+
+
+        The wait operations are scheduled to start as soon as possible on each channel.
+
+
+        The relative timing between channels is not guaranteed.'
+      properties:
+        op_type:
+          const: wait
+          default: wait
+          title: Op Type
+          type: string
+        channels:
+          items:
+            $ref: '#/components/schemas/ChannelRef'
+          title: Channels
+          type: array
+        duration:
+          $ref: '#/components/schemas/Duration'
+      required:
+      - channels
+      - duration
+      title: Wait
+      type: object
+    complex_from_tuple:
+      anyOf:
+      - items:
+          type: number
+        maxItems: 2
+        minItems: 2
+        type: array
+      - pattern: ^[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?[+-](\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?j$
+        type: string
+tags:
+- name: basic-types
+  description: Basic types like Amplitude, Duration, Frequency, etc.
+- name: pulse-types
+  description: Pulse type definitions (Square, Sine, Arbitrary, etc.)
+- name: channel-ops
+  description: Channel operations (Play, Record, Barrier, etc.)
+- name: control-flow
+  description: Control flow operations (Repetition, Iteration, Conditional)
+- name: data-ops
+  description: Data operations (Assignment, Arithmetic, etc.)
+- name: sequences
+  description: Operation sequences and schedules
+- name: reference-types
+  description: Reference types for variables and parameters
+- name: units
+  description: Unit types (Seconds, Volts, Hertz, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,11 +22,13 @@ dependencies = [
 "Homepage" = "https://github.com/equal1/eq1_pulse"
 
 [project.optional-dependencies]
-dev = ["pre-commit", "eq1_pulse[typing, mypy, pyright, ruff, pytest, doc]"]
+dev = ["pre-commit", "eq1_pulse[typing, mypy, pyright, ruff, pytest, doc, yaml]"]
 
 qblox = ["spirack", "qblox_instruments>=0.11", "dataclasses_json>=0.5.2"]
 
 mypy = ["mypy>=1.16.0", "eq1_pulse[typing]"]
+
+yaml = ["ruamel.yaml"]
 
 pyright = ["pyright!=1.1.407", "eq1_pulse[typing]"]
 

--- a/setup/unix/update_dev_environment.sh
+++ b/setup/unix/update_dev_environment.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -xe
 cd $(dirname "$0")
 conda env update --name eq1_pulse-dev --prune --file ../conda_envs/conda_env.yaml "$@"
-conda run --live-stream -n eq1_pulse-dev ./install_eq1lab.sh dev
+conda run --live-stream -n eq1_pulse-dev ./install_eq1_pulse.sh dev

--- a/src/eq1_pulse/__init__.py
+++ b/src/eq1_pulse/__init__.py
@@ -1,0 +1,10 @@
+from importlib.metadata import PackageNotFoundError  # noqa: D104
+from importlib.metadata import version as _get_version
+
+try:
+    __version__ = _get_version(__name__)
+except PackageNotFoundError:
+    # Package is not installed, set a default version
+    __version__ = "0.0.0"
+finally:
+    del _get_version, PackageNotFoundError

--- a/src/eq1_pulse/utilities/__init__.py
+++ b/src/eq1_pulse/utilities/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for the eq1_pulse package."""

--- a/src/eq1_pulse/utilities/openapi_generator.py
+++ b/src/eq1_pulse/utilities/openapi_generator.py
@@ -1,0 +1,309 @@
+"""Generate OpenAPI schema from the eq1_pulse models package.
+
+This module provides functionality to generate OpenAPI 3.1.0 schemas from the
+Pydantic models defined in the eq1_pulse.models package. It follows the approach
+outlined in the `Speakeasy Pydantic guide <https://www.speakeasy.com/openapi/frameworks/pydantic>`_
+article.
+
+The generated schema includes all model definitions with proper references,
+descriptions, examples, and can be exported to YAML or JSON format.
+
+.. code-block:: python
+
+    from eq1_pulse.utilities.openapi_generator import generate_openapi_schema, save_openapi_schema
+
+    # Generate the schema
+    schema = generate_openapi_schema()
+
+    # Save to YAML file
+    save_openapi_schema(schema, "openapi.yaml", format="yaml")
+
+    # Save to JSON file
+    save_openapi_schema(schema, "openapi.json", format="json")
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+from pydantic.json_schema import models_json_schema
+
+from eq1_pulse import __version__ as _eq1_pulse_version
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+__all__ = (
+    "generate_openapi_schema",
+    "get_all_pydantic_models",
+    "save_openapi_schema",
+)
+
+
+def get_all_pydantic_models() -> list[type[BaseModel]]:
+    """Discover and return all Pydantic models from the eq1_pulse.models package.
+
+    This function dynamically imports all modules in the models package and
+    extracts Pydantic BaseModel subclasses, excluding abstract base classes
+    and internal models.
+
+    :return: List of Pydantic model classes found in the models package
+
+    .. note::
+
+        This function filters out base classes like :class:`NoExtrasModel`,
+        :class:`FrozenModel`, etc., to only include concrete model definitions.
+
+    Examples
+
+    .. code-block:: python
+
+        models = get_all_pydantic_models()
+        print(f"Found {len(models)} models")
+        for model in models:
+            print(f"  - {model.__name__}")
+    """
+    # List of modules to import from the models package
+    model_modules = [
+        "arithmetic",
+        "base_models",
+        "basic_types",
+        "channel_ops",
+        "complex",
+        "control_flow",
+        "data_ops",
+        "identifier_str",
+        "nd_array",
+        "pulse_types",
+        "reference_types",
+        "schedule",
+        "sequence",
+        "units",
+    ]
+
+    # Base classes to exclude from the schema
+    excluded_base_classes = {
+        "NoExtrasModel",
+        "FrozenModel",
+        "LeanModel",
+        "FrozenLeanModel",
+        "WrappedValueModel",
+        "FrozenWrappedValueModel",
+        "WrappedValueOrZeroModel",
+        "OpBase",
+        "PulseBase",
+        "SequenceBase",
+        "RepetitionBase",
+        "IterationBase",
+        "ConditionalBase",
+    }
+
+    pydantic_models = []
+
+    for module_name in model_modules:
+        try:
+            module = importlib.import_module(f"eq1_pulse.models.{module_name}")
+
+            # Get all classes from the module
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                # Check if it's a Pydantic model and not a base class
+                if (
+                    issubclass(obj, BaseModel)
+                    and obj.__module__.startswith("eq1_pulse.models")
+                    and name not in excluded_base_classes
+                    and not name.startswith("_")
+                    and obj not in pydantic_models
+                ):
+                    # Avoid duplicates
+                    pydantic_models.append(obj)
+        except ImportError as e:
+            print(f"Warning: Could not import module {module_name}: {e}")
+
+    return pydantic_models
+
+
+def generate_openapi_schema(
+    title: str = "Equal1 Pulse Models API",
+    version: str = _eq1_pulse_version,
+    description: str | None = None,
+    include_tags: bool = True,
+) -> dict[str, Any]:
+    """Generate a complete OpenAPI 3.1.0 schema from eq1_pulse models.
+
+    This function creates a comprehensive OpenAPI schema document that includes
+    all Pydantic models from the eq1_pulse.models package. The schema uses the
+    OpenAPI 3.1.0 format with proper component references.
+
+    :param title: The title of the API in the OpenAPI document
+    :param version: The version of the API
+    :param description: Optional description of the API. If :obj:`None`, a default
+        description will be used
+    :param include_tags: Whether to include tags in the schema for grouping models
+
+    :return: Dictionary representation of the OpenAPI schema
+
+    Examples
+
+    .. code-block:: python
+
+        schema = generate_openapi_schema(
+            title="My Pulse API",
+            version="2.0.0",
+            description="Custom API for pulse control"
+        )
+
+    .. note::
+
+        The generated schema uses ``#/components/schemas`` for references,
+        which is the standard OpenAPI format compatible with SDK generators
+        like Speakeasy.
+    """
+    if description is None:
+        description = (
+            "OpenAPI schema for Equal1 Pulse library models. "
+            "This schema defines all the Pydantic models used for pulse sequencing, "
+            "channel operations, control flow, and data operations."
+        )
+
+    # Get all Pydantic models
+    models_list = get_all_pydantic_models()
+
+    if not models_list:
+        raise ValueError("No Pydantic models found in eq1_pulse.models package")
+
+    # Generate JSON schema for all models with OpenAPI-compatible references
+    # models_json_schema expects a list of tuples (model, mode)
+    models_with_mode: list[tuple[type[BaseModel], Literal["validation", "serialization"]]] = [
+        (model, "validation") for model in models_list
+    ]
+    _, definitions = models_json_schema(
+        models_with_mode,
+        ref_template="#/components/schemas/{model}",
+        title="Equal1 Pulse Models",
+    )
+
+    # Build the OpenAPI document structure
+    openapi_doc: dict[str, Any] = {
+        "openapi": "3.1.0",
+        "info": {
+            "title": title,
+            "version": version,
+            "description": description,
+        },
+        "components": {
+            "schemas": definitions.get("$defs", {}),
+        },
+        "paths": {},
+    }
+
+    # Add tags if requested
+    if include_tags:
+        tags = [
+            {"name": "basic-types", "description": "Basic types like Amplitude, Duration, Frequency, etc."},
+            {"name": "pulse-types", "description": "Pulse type definitions (Square, Sine, Arbitrary, etc.)"},
+            {"name": "channel-ops", "description": "Channel operations (Play, Record, Barrier, etc.)"},
+            {"name": "control-flow", "description": "Control flow operations (Repetition, Iteration, Conditional)"},
+            {"name": "data-ops", "description": "Data operations (Assignment, Arithmetic, etc.)"},
+            {"name": "sequences", "description": "Operation sequences and schedules"},
+            {"name": "reference-types", "description": "Reference types for variables and parameters"},
+            {"name": "units", "description": "Unit types (Seconds, Volts, Hertz, etc.)"},
+        ]
+        openapi_doc["tags"] = tags
+
+    return openapi_doc
+
+
+def save_openapi_schema(
+    schema: dict[str, Any],
+    output_path: str | Path,
+    format: str = "yaml",
+) -> None:
+    """Save the OpenAPI schema to a file in YAML or JSON format.
+
+    :param schema: The OpenAPI schema dictionary to save
+    :param output_path: Path where the schema file should be saved
+    :param format: Output format, either ``"yaml"`` or ``"json"``
+
+    :raises ValueError: If an unsupported format is specified
+    :raises ImportError: If ruamel.yaml is not installed and YAML format is requested
+
+    Examples
+
+    .. code-block:: python
+
+        schema = generate_openapi_schema()
+
+        # Save as YAML
+        save_openapi_schema(schema, "openapi.yaml", format="yaml")
+
+        # Save as JSON
+        save_openapi_schema(schema, "openapi.json", format="json")
+    """
+    output_path = Path(output_path)
+
+    if format.lower() == "yaml":
+        try:
+            from ruamel.yaml import YAML
+        except ImportError as e:
+            raise ImportError(
+                "ruamel.yaml is required to save schema in YAML format. Install it with: pip install ruamel.yaml"
+            ) from e
+
+        yaml = YAML()
+        yaml.default_flow_style = False
+        yaml.preserve_quotes = True
+        yaml.width = 4096  # Prevent line wrapping
+
+        with output_path.open("w") as f:
+            yaml.dump(schema, f)
+    elif format.lower() == "json":
+        with output_path.open("w") as f:
+            json.dump(schema, f, indent=2)
+    else:
+        raise ValueError(f"Unsupported format: {format}. Use 'yaml' or 'json'.")
+
+
+def main() -> None:
+    """Generate and save the OpenAPI schema for eq1_pulse models.
+
+    This is a convenience function that can be run as a script to generate
+    both YAML and JSON versions of the OpenAPI schema.
+
+    Examples
+
+    .. code-block:: bash
+
+        python -m eq1_pulse.utilities.openapi_generator
+    """
+    print("Generating OpenAPI schema for eq1_pulse models...")
+
+    # Generate the schema
+    schema = generate_openapi_schema()
+
+    # Get the number of models
+    num_models = len(schema.get("components", {}).get("schemas", {}))
+    print(f"Found {num_models} model schemas")
+
+    # Save to YAML
+    yaml_path = Path("openapi.yaml")
+    try:
+        save_openapi_schema(schema, yaml_path, format="yaml")
+        print(f"✓ Saved OpenAPI schema to {yaml_path}")
+    except ImportError:
+        print("✗ Could not save YAML (ruamel.yaml not installed)")
+
+    # Save to JSON
+    json_path = Path("openapi.json")
+    save_openapi_schema(schema, json_path, format="json")
+    print(f"✓ Saved OpenAPI schema to {json_path}")
+
+    print("\nSchema generation complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_openapi_generator.py
+++ b/tests/test_openapi_generator.py
@@ -1,0 +1,185 @@
+"""Tests for the OpenAPI schema generator module."""
+
+import sys
+from pathlib import Path
+
+# Add src to path for testing
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import json
+from tempfile import TemporaryDirectory
+
+import pytest
+from pydantic import BaseModel
+
+from eq1_pulse.utilities.openapi_generator import (
+    generate_openapi_schema,
+    get_all_pydantic_models,
+    save_openapi_schema,
+)
+
+
+def test_get_all_pydantic_models():
+    """Test that we can discover all Pydantic models."""
+    models = get_all_pydantic_models()
+
+    # Should find at least some models
+    assert len(models) > 0, "Should discover at least one model"
+
+    # All should be BaseModel subclasses
+    for model in models:
+        assert issubclass(model, BaseModel), f"{model.__name__} should be a BaseModel subclass"
+
+    # Should not include base classes
+    excluded_names = {"NoExtrasModel", "FrozenModel", "LeanModel"}
+    model_names = {m.__name__ for m in models}
+    assert not model_names & excluded_names, "Should not include base classes"
+
+
+def test_generate_openapi_schema():
+    """Test OpenAPI schema generation."""
+    schema = generate_openapi_schema()
+
+    # Check basic structure
+    assert "openapi" in schema
+    assert schema["openapi"] == "3.1.0"
+
+    assert "info" in schema
+    assert "title" in schema["info"]
+    assert "version" in schema["info"]
+    assert "description" in schema["info"]
+
+    assert "components" in schema
+    assert "schemas" in schema["components"]
+
+    # Should have schemas for models
+    assert len(schema["components"]["schemas"]) > 0
+
+    # Should have tags
+    assert "tags" in schema
+    assert len(schema["tags"]) > 0
+
+    # Should have empty paths
+    assert "paths" in schema
+    assert len(schema["paths"]) == 0
+
+
+def test_generate_openapi_schema_custom_params():
+    """Test OpenAPI schema generation with custom parameters."""
+    schema = generate_openapi_schema(
+        title="Custom Title",
+        version="2.0.0",
+        description="Custom description",
+        include_tags=False,
+    )
+
+    assert schema["info"]["title"] == "Custom Title"
+    assert schema["info"]["version"] == "2.0.0"
+    assert schema["info"]["description"] == "Custom description"
+    assert "tags" not in schema
+
+
+def test_save_openapi_schema_json():
+    """Test saving schema to JSON format."""
+    schema = generate_openapi_schema()
+
+    with TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "test_schema.json"
+        save_openapi_schema(schema, output_path, format="json")
+
+        assert output_path.exists()
+
+        # Verify it's valid JSON
+        with output_path.open() as f:
+            loaded_schema = json.load(f)
+
+        assert loaded_schema["openapi"] == "3.1.0"
+        assert "components" in loaded_schema
+
+
+def test_save_openapi_schema_yaml():
+    """Test saving schema to YAML format."""
+    pytest.importorskip("ruamel.yaml")  # Skip if ruamel.yaml not installed
+
+    schema = generate_openapi_schema()
+
+    with TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "test_schema.yaml"
+        save_openapi_schema(schema, output_path, format="yaml")
+
+        assert output_path.exists()
+
+        # Verify it's valid YAML
+        from ruamel.yaml import YAML
+
+        yaml = YAML()
+        with output_path.open() as f:
+            loaded_schema = yaml.load(f)
+
+        assert loaded_schema["openapi"] == "3.1.0"
+        assert "components" in loaded_schema
+
+
+def test_save_openapi_schema_invalid_format():
+    """Test that invalid format raises ValueError."""
+    schema = generate_openapi_schema()
+
+    with TemporaryDirectory() as tmpdir:
+        output_path = Path(tmpdir) / "test_schema.txt"
+
+        with pytest.raises(ValueError, match="Unsupported format"):
+            save_openapi_schema(schema, output_path, format="txt")
+
+
+def test_schema_contains_expected_models():
+    """Test that schema contains some expected model types."""
+    schema = generate_openapi_schema()
+    schemas = schema["components"]["schemas"]
+
+    # Check for some expected model types (these should exist in the models package)
+    expected_model_patterns = ["Pulse", "Operation", "Sequence"]
+
+    # At least one schema name should contain one of these patterns
+    schema_names = list(schemas.keys())
+    found_patterns = []
+
+    for pattern in expected_model_patterns:
+        if any(pattern.lower() in name.lower() for name in schema_names):
+            found_patterns.append(pattern)
+
+    assert len(found_patterns) > 0, f"Expected to find models matching {expected_model_patterns}"
+
+
+if __name__ == "__main__":
+    # Run tests with pytest if available, otherwise run directly
+    try:
+        import pytest
+
+        pytest.main([__file__, "-v"])
+    except ImportError:
+        print("Running tests without pytest...")
+        test_get_all_pydantic_models()
+        print("✓ test_get_all_pydantic_models passed")
+
+        test_generate_openapi_schema()
+        print("✓ test_generate_openapi_schema passed")
+
+        test_generate_openapi_schema_custom_params()
+        print("✓ test_generate_openapi_schema_custom_params passed")
+
+        test_save_openapi_schema_json()
+        print("✓ test_save_openapi_schema_json passed")
+
+        try:
+            test_save_openapi_schema_yaml()
+            print("✓ test_save_openapi_schema_yaml passed")
+        except ModuleNotFoundError:
+            print("⊘ test_save_openapi_schema_yaml skipped (ruamel.yaml not installed)")
+
+        test_save_openapi_schema_invalid_format()
+        print("✓ test_save_openapi_schema_invalid_format passed")
+
+        test_schema_contains_expected_models()
+        print("✓ test_schema_contains_expected_models passed")
+
+        print("\nAll tests passed!")


### PR DESCRIPTION
- create `openapi_generator.py` to generate OpenAPI 3.1.0 schemas from Pydantic models in the eq1_pulse package.
- add functions to discover Pydantic models, generate schemas, and save them in YAML or JSON formats.
- add `ruamel.yaml` as a dependency for YAML support in the project, updated `pyproject.toml`
- add versioning to OpenAPI schema generation and update documentation